### PR TITLE
Add Kubernetes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0+1.5.8
 
-- add support for Kubernetes
+- add support for Kubernetes by allowing to optionally also install `runc`, `crtcl` and `CNI` plugins. `containerd` builds are available in two flavors: Either just the `containerd` binaries or `containerd` binaries plus everything else needed to use `containerd` together with Kubernetes. Please see [defaults/main.yml](https://github.com/githubixx/ansible-role-containerd/tree/master/defaults/main.yml) for all possible settings. With the Kubernetes support a lot of new variables were introduced but for almost all the default values should be good enough.
 
 ## 0.1.1+1.5.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
-Changelog
----------
+# Changelog
 
-**0.1.1+1.5.8**
+## 0.2.0+1.5.8
+
+- add support for Kubernetes
+
+## 0.1.1+1.5.8
 
 - update `containerd` to `v1.5.8`
 
-**0.1.0+1.5.7**
+## 0.1.0+1.5.7
 
 - update `containerd` to `v1.5.7`
 
-**0.1.0+1.5.5**
+## 0.1.0+1.5.5
 
 - initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0+1.5.8
 
-- add support for Kubernetes by allowing to optionally also install `runc`, `crtcl` and `CNI` plugins. `containerd` builds are available in two flavors: Either just the `containerd` binaries or `containerd` binaries plus everything else needed to use `containerd` together with Kubernetes. Please see [defaults/main.yml](https://github.com/githubixx/ansible-role-containerd/tree/master/defaults/main.yml) for all possible settings. With the Kubernetes support a lot of new variables were introduced but for almost all the default values should be good enough.
+- add support for Kubernetes by allowing to optionally also install `runc`, `crtcl` and `CNI` plugins. `containerd` builds are available in two flavors: Either just the `containerd` binaries or `containerd` binaries plus everything else needed to use `containerd` together with Kubernetes. Please see [defaults/main.yml](https://github.com/githubixx/ansible-role-containerd/tree/master/defaults/main.yml) for all possible settings. With the Kubernetes support a lot of new variables were introduced but for almost all the default values should be good enough. The default `containerd_flavor: "base"` mimics the behavior of the previous version of this role. So upgrading shouldn't be an issue.
 
 ## 0.1.1+1.5.8
 

--- a/README.md
+++ b/README.md
@@ -13,19 +13,62 @@ Changelog
 
 see [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/master/CHANGELOG.md)
 
-
 Role Variables
 --------------
 
 ```yaml
+# "containerd" is distributed in two flavors. Possible values:
+#
+# - base
+# - k8s
+#
+# First difference is the download size:
+# Choosing "base" will download around 35 MByte of data during installation.
+# Choosing "k8s" will download around 100 MByte of data during installation.
+#
+# If you choose "base" the role will only install a minimal set of
+# "containerd" binaries:
+#
+# containerd, containerd-shim, containerd-shim-runc-v1, containerd-shim-runc-v2
+# and ctr.
+#
+# Please note: Specifying "base" also means that no "runc" will be installed.
+# "runc" needs to be available before this role gets installed. So make sure
+# that "runc" is already installed if you don't want to use the "k8s" flavor.
+# To install "runc" separately you can also use this Ansible role:
+#
+# - https://github.com/githubixx/ansible-role-runc
+# - https://galaxy.ansible.com/githubixx/runc
+#
+# If you choose "k8s" this role will install a set of files specifically for
+# Kubernetes. It contains all required binaries and files for using containerd
+# with Kubernetes. Besides the binaries mentioned above it additionally contains:
+#
+# crictl, critest and runc
+#
+# "runc" can also be installed separately if it's already installed by a
+# different process (see further down below).
+#
+# It also contains the CNI binaries which currently are:
+#
+# vlan, host-local, flannel, bridge, host-device, tuning, firewall, bandwidth,
+# ipvlan, sbr, dhcp, portmap, ptp, static, macvlan, loopback
+#
+# So no need to install them seperately. But this role also allows you to skip
+# CNI installation (see further down below).
+#
+# Before 0.2.0+1.5.8 of this role this setting wasn't available but "base"
+# basically mimics this behavior.
+containerd_flavor: "base"
+
 # containerd version to install
 containerd_version: "1.5.8"
 
-# Where to install "containerd" binaries.
-containerd_bin_directory: "/usr/local/bin"
+# Directory where to store "containerd" binaries
+containerd_binary_directory: "/usr/local/bin"
 
 # Location of containerd configuration file
-containerd_conf_directory: "/etc/containerd"
+containerd_config_directory: "/etc/containerd"
 
 # Directory to store the archive
 containerd_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
@@ -38,24 +81,27 @@ containerd_group: "root"
 # Specifies the permissions of the "containerd" binaries
 containerd_binary_mode: "0755"
 
-# Operarting system
+# Operating system
 # Possible options: "linux", "windows"
 containerd_os: "linux"
 
 # Processor architecture "containerd" should run on.
-# Other possible values: "386","arm64","arm"
+# Other possible values: "arm64","arm"
 containerd_arch: "amd64"
 
 # Name of the archive file name
-containerd_archive: "containerd-{{ containerd_version }}-{{ containerd_os }}-{{ containerd_arch }}.tar.gz"
+containerd_archive_base: "containerd-{{ containerd_version }}-{{ containerd_os }}-{{ containerd_arch }}.tar.gz"
+
+# Name of the release tarball specifically for Kubernetes
+containerd_archive_k8s: "cri-containerd-cni-{{ containerd_version }}-{{ containerd_os }}-{{ containerd_arch }}.tar.gz"
 
 # The containerd download URL (normally no need to change it)
-containerd_url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/{{ containerd_archive }}"
+containerd_url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/{{ containerd_archive_base if containerd_flavor == 'base' else containerd_archive_k8s }}"
 
 # containerd systemd service settings
 containerd_service_settings:
   "ExecStartPre": "{{ modprobe_location }} overlay"
-  "ExecStart": "{{ containerd_bin_directory }}/containerd"
+  "ExecStart": "{{ containerd_binary_directory }}/containerd"
   "Restart": "always"
   "RestartSec": "5"
   "Delegate": "yes"
@@ -65,21 +111,385 @@ containerd_service_settings:
   "LimitNPROC": "infinity"
   "LimitCORE": "infinity"
 
-# containerd configuration
+# Content of configuration file of containerd. The settings below are the
+# default "containerd" settings generated with the following command (needs
+# "containerd" binary installed of course):
+#
+# containerd config default
+#
+# The configuration file contains a few role variables that will be replaced when
+# the configuration template is processed.
+#
 containerd_config: |
+  disabled_plugins = []
+  imports = []
+  oom_score = 0
+  plugin_dir = ""
+  required_plugins = []
+  root = "/var/lib/containerd"
+  state = "/run/containerd"
+  version = 2
+
+  [cgroup]
+    path = ""
+
+  [debug]
+    address = ""
+    format = ""
+    gid = 0
+    level = ""
+    uid = 0
+
+  [grpc]
+    address = "/run/containerd/containerd.sock"
+    gid = 0
+    max_recv_message_size = 16777216
+    max_send_message_size = 16777216
+    tcp_address = ""
+    tcp_tls_cert = ""
+    tcp_tls_key = ""
+    uid = 0
+
+  [metrics]
+    address = ""
+    grpc_histogram = false
+
   [plugins]
-    [plugins.cri.containerd]
-      snapshotter = "overlayfs"
-      [plugins.cri.containerd.default_runtime]
-        runtime_type = "io.containerd.runtime.v1.linux"
-        runtime_engine = "/usr/local/bin/runc"
-        runtime_root = ""
+
+    [plugins."io.containerd.gc.v1.scheduler"]
+      deletion_threshold = 0
+      mutation_threshold = 100
+      pause_threshold = 0.02
+      schedule_delay = "0s"
+      startup_delay = "100ms"
+
+    [plugins."io.containerd.grpc.v1.cri"]
+      disable_apparmor = false
+      disable_cgroup = false
+      disable_hugetlb_controller = true
+      disable_proc_mount = false
+      disable_tcp_service = true
+      enable_selinux = false
+      enable_tls_streaming = false
+      ignore_image_defined_volumes = false
+      max_concurrent_downloads = 3
+      max_container_log_line_size = 16384
+      netns_mounts_under_state_dir = false
+      restrict_oom_score_adj = false
+      sandbox_image = "k8s.gcr.io/pause:3.5"
+      selinux_category_range = 1024
+      stats_collect_period = 10
+      stream_idle_timeout = "4h0m0s"
+      stream_server_address = "127.0.0.1"
+      stream_server_port = "0"
+      systemd_cgroup = false
+      tolerate_missing_hugetlb_controller = true
+      unset_seccomp_profile = ""
+
+      [plugins."io.containerd.grpc.v1.cri".cni]
+        bin_dir = "{% if containerd_cni_binary_directory is defined %}{{ containerd_cni_binary_directory }}{% else %}/opt/cni/bin{% endif -%}"
+        conf_dir = "{% if containerd_cni_netconfig_directory is defined %}{{ containerd_cni_netconfig_directory }}{% else %}/etc/cni/net.d{% endif %}"
+        conf_template = ""
+        max_conf_num = 1
+
+      [plugins."io.containerd.grpc.v1.cri".containerd]
+        default_runtime_name = "runc"
+        disable_snapshot_annotations = true
+        discard_unpacked_layers = false
+        no_pivot = false
+        snapshotter = "overlayfs"
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+          base_runtime_spec = ""
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_root = ""
+          runtime_type = ""
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+            base_runtime_spec = ""
+            container_annotations = []
+            pod_annotations = []
+            privileged_without_host_devices = false
+            runtime_engine = ""
+            runtime_root = ""
+            runtime_type = "io.containerd.runc.v2"
+
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+              BinaryName = ""
+              CriuImagePath = ""
+              CriuPath = ""
+              CriuWorkPath = ""
+              IoGid = 0
+              IoUid = 0
+              NoNewKeyring = false
+              NoPivotRoot = false
+              Root = ""
+              ShimCgroup = ""
+              SystemdCgroup = false
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+          base_runtime_spec = ""
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_root = ""
+          runtime_type = ""
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".image_decryption]
+        key_model = "node"
+
+      [plugins."io.containerd.grpc.v1.cri".registry]
+        config_path = ""
+
+        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+      [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+        tls_cert_file = ""
+        tls_key_file = ""
+
+    [plugins."io.containerd.internal.v1.opt"]
+      path = "/opt/containerd"
+
+    [plugins."io.containerd.internal.v1.restart"]
+      interval = "10s"
+
+    [plugins."io.containerd.metadata.v1.bolt"]
+      content_sharing_policy = "shared"
+
+    [plugins."io.containerd.monitor.v1.cgroups"]
+      no_prometheus = false
+
+    [plugins."io.containerd.runtime.v1.linux"]
+      no_shim = false
+      runtime = "runc"
+      runtime_root = ""
+      shim = "containerd-shim"
+      shim_debug = false
+
+    [plugins."io.containerd.runtime.v2.task"]
+      platforms = ["linux/amd64"]
+
+    [plugins."io.containerd.service.v1.diff-service"]
+      default = ["walking"]
+
+    [plugins."io.containerd.snapshotter.v1.aufs"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.btrfs"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.devmapper"]
+      async_remove = false
+      base_image_size = ""
+      pool_name = ""
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.native"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.overlayfs"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.zfs"]
+      root_path = ""
+
+  [proxy_plugins]
+
+  [stream_processors]
+
+    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+      accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+      args = ["--decryption-keys-path", "{{ containerd_config_directory }}/ocicrypt/keys"]
+      env = ["OCICRYPT_KEYPROVIDER_CONFIG={{ containerd_config_directory }}/ocicrypt/ocicrypt_keyprovider.conf"]
+      path = "ctd-decoder"
+      returns = "application/vnd.oci.image.layer.v1.tar"
+
+    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+      accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+      args = ["--decryption-keys-path", "{{ containerd_config_directory }}/ocicrypt/keys"]
+      env = ["OCICRYPT_KEYPROVIDER_CONFIG={{ containerd_config_directory }}/ocicrypt/ocicrypt_keyprovider.conf"]
+      path = "ctd-decoder"
+      returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+  [timeouts]
+    "io.containerd.timeout.shim.cleanup" = "5s"
+    "io.containerd.timeout.shim.load" = "5s"
+    "io.containerd.timeout.shim.shutdown" = "3s"
+    "io.containerd.timeout.task.state" = "2s"
+
+  [ttrpc]
+    address = ""
+    gid = 0
+    uid = 0
+
+
+#################################################
+# runc
+#################################################
+
+# Directory where to store the "runc" binary.
+#
+# As mentioned above if "containerd_flavor: base" was specified "runc" needs
+# to be installed seperately. Without a "runc" binary containerd won't work.
+#
+# Commented by default. If "runc" should be installed just remove the comment
+# and adjust the value if needed. But the default should be just fine.
+# As long as "containerd_runc_binary_directory" is commented all the other
+# "containerd_runc_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_runc_binary_directory: "/usr/local/sbin"
+
+# Owner/group of "runc" binary. If the variables are not set
+# the resulting binary will be owned by the current user.
+containerd_runc_owner: "root"
+containerd_runc_group: "root"
+
+# Specifies the permissions of the "runc" binary
+containerd_runc_binary_mode: "0755"
+
+
+#################################################
+# crictl
+#################################################
+
+# Configuration file for "crictl" (client for CRI).
+#
+# Commented by default. If "crictl" should be installed just remove the
+# comments and adjust the values if needed. But the defaults should be just fine.
+# As long as "containerd_crictl_config_(file|directory)" are commented all the other
+# "containerd_crictl_config_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_crictl_config_file: "crictl.yaml"
+# containerd_crictl_config_directory: "/etc"
+
+# Directory permissions for directory defined in "containerd_crictl_config_directory"
+# As the default for this directory is "/etc" be careful about permissions!
+# If this variable is not specified the default is "0755".
+containerd_crictl_config_directory_mode: "0755"
+
+# Owner/group of directory defined in "containerd_crictl_config_directory".
+# As the default for this directory is "/etc" be careful about ownership!
+# If these variables are not specified the default owner is "root" / group "root".
+containerd_crictl_config_directory_owner: "root"
+containerd_crictl_config_directory_group: "root"
+
+# Owner/group of "crictl.yaml". If the variables are not set
+# the resulting binary will be owned by the current user.
+containerd_crictl_config_file_owner: "root"
+containerd_crictl_config_file_group: "root"
+
+# Specifies the permissions of the "crictl.yaml" file.
+containerd_crictl_config_file_mode: "0644"
+
+containerd_crictl_config_file_content: |
+  runtime-endpoint: unix:///run/containerd/containerd.sock
+
+
+#################################################
+# CNI
+#################################################
+
+# Directory where to store the CNI binaries.
+#
+# Commented by default. If CNI binaries should be installed just remove the
+# comment and adjust the value if needed. But the default should be just fine.
+# As long as "containerd_cni_binary_directory" is commented all the other
+# "containerd_cni_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_cni_binary_directory: "/opt/cni/bin"
+
+# Directory permissions for directory containing CNI binaries
+containerd_cni_binary_directory_mode: "0755"
+
+# Owner/group of CNI binaries. If the variables are not set
+# the resulting binary will be owned by the current user.
+containerd_cni_binary_owner: "root"
+containerd_cni_binary_group: "root"
+
+# Specifies the permissions of the "CNI" files.
+containerd_cni_binary_mode: "0755"
+
+# Name of the CNI network configuration file and the directory where this file
+# should be placed.
+# These variables are commented by default which means that no CNI network
+# configuration file will be created. Some Kubernetes networking platforms like
+# "Cilium" are creating this file on the fly while starting up on a K8s node.
+# So in this case it's sufficient to only have the CNI binaries installed.
+# As long as "containerd_cni_netconfig_(file|directory)" are commented all the other
+# "containerd_cni_netconfig_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_cni_netconfig_file: "10-containerd-net.conflist"
+# containerd_cni_netconfig_directory: "/etc/cni/net.d"
+
+# Directory permissions of network configuration directory
+containerd_cni_netconfig_directory_mode: "0755"
+
+# Owner/group of CNI network configuration file. If these variables are not set
+# the file will be owned by the current user.
+containerd_cni_netconfig_file_owner: "root"
+containerd_cni_netconfig_file_group: "root"
+
+# Specifies the permissions of the file specified in "containerd_cni_netconfig_file"
+containerd_cni_netconfig_file_mode: "0644"
+
+# Content of CNI network configuration file. This is only an example! Please
+# adjust to your needs! If this variable is commented the configuration file
+# specified in "containerd_cni_netconfig_file" won't be created.
+containerd_cni_netconfig_file_content: |
+  {
+    "cniVersion": "0.4.0",
+    "name": "containerd-net",
+    "plugins": [
+      {
+        "type": "bridge",
+        "bridge": "cni0",
+        "isGateway": true,
+        "ipMasq": true,
+        "promiscMode": true,
+        "ipam": {
+          "type": "host-local",
+          "ranges": [
+            [{
+              "subnet": "10.88.0.0/16"
+            }],
+            [{
+              "subnet": "2001:4860:4860::/64"
+            }]
+          ],
+          "routes": [
+            { "dst": "0.0.0.0/0" },
+            { "dst": "::/0" }
+          ]
+        }
+      },
+      {
+        "type": "portmap",
+        "capabilities": {"portMappings": true}
+      }
+    ]
+  }
 ```
 
 Dependencies
 ------------
 
-[githubixx.runc](https://galaxy.ansible.com/githubixx/runc)
+[githubixx.runc](https://galaxy.ansible.com/githubixx/runc) is an optional dependency in case `containerd_flavor` is set to `base`. But in general every Ansible role that installs `runc` binary should be good enough. In case `runc` is already installed this dependency can be ignored.
 
 Example Playbook
 ----------------
@@ -89,6 +499,8 @@ Example Playbook
   roles:
     - githubixx.containerd
 ```
+
+More examples are available in the [Molecule tests](https://github.com/githubixx/ansible-role-containerd/tree/master/molecule/kvm).
 
 Testing
 -------
@@ -101,7 +513,7 @@ Afterwards molecule can be executed:
 molecule converge -s kvm
 ```
 
-This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `runc` plus `containerd`.
+This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `containerd` and optionally `runc`, `crictl` and the `CNI` plugins (which are needed by Kubernetes e.g.).
 
 To clean up run
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,14 +2,58 @@
 # Copyright (C) 2021 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# "containerd" is distributed in two flavors. Possible values:
+#
+# - base
+# - k8s
+#
+# First difference is the download size:
+# Choosing "base" will download around 35 MByte of data during installation.
+# Choosing "k8s" will download around 100 MByte of data during installation.
+#
+# If you choose "base" the role will only install a minimal set of
+# "containerd" binaries:
+#
+# containerd, containerd-shim, containerd-shim-runc-v1, containerd-shim-runc-v2
+# and ctr.
+#
+# Please note: Specifying "base" also means that no "runc" will be installed.
+# "runc" needs to be available before this role gets installed. So make sure
+# that "runc" is already installed if you don't want to use the "k8s" flavor.
+# To install "runc" separately you can also use this Ansible role:
+#
+# - https://github.com/githubixx/ansible-role-runc
+# - https://galaxy.ansible.com/githubixx/runc
+#
+# If you choose "k8s" this role will install a set of files specifically for
+# Kubernetes. It contains all required binaries and files for using containerd
+# with Kubernetes. Besides the binaries mentioned above it additionally contains:
+#
+# crictl, critest and runc
+#
+# "runc" can also be installed separately if it's already installed by a
+# different process (see further down below).
+#
+# It also contains the CNI binaries which currently are:
+#
+# vlan, host-local, flannel, bridge, host-device, tuning, firewall, bandwidth,
+# ipvlan, sbr, dhcp, portmap, ptp, static, macvlan, loopback
+#
+# So no need to install them seperately. But this role also allows you to skip
+# CNI installation (see further down below).
+#
+# Before 0.2.0+1.5.8 of this role this setting wasn't available but "base"
+# basically mimics this behavior.
+containerd_flavor: "base"
+
 # containerd version to install
 containerd_version: "1.5.8"
 
-# Where to install "containerd" binaries.
-containerd_bin_directory: "/usr/local/bin"
+# Directory where to store "containerd" binaries
+containerd_binary_directory: "/usr/local/bin"
 
 # Location of containerd configuration file
-containerd_conf_directory: "/etc/containerd"
+containerd_config_directory: "/etc/containerd"
 
 # Directory to store the archive
 containerd_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
@@ -22,7 +66,7 @@ containerd_group: "root"
 # Specifies the permissions of the "containerd" binaries
 containerd_binary_mode: "0755"
 
-# Operarting system
+# Operating system
 # Possible options: "linux", "windows"
 containerd_os: "linux"
 
@@ -31,15 +75,18 @@ containerd_os: "linux"
 containerd_arch: "amd64"
 
 # Name of the archive file name
-containerd_archive: "containerd-{{ containerd_version }}-{{ containerd_os }}-{{ containerd_arch }}.tar.gz"
+containerd_archive_base: "containerd-{{ containerd_version }}-{{ containerd_os }}-{{ containerd_arch }}.tar.gz"
+
+# Name of the release tarball specifically for Kubernetes
+containerd_archive_k8s: "cri-containerd-cni-{{ containerd_version }}-{{ containerd_os }}-{{ containerd_arch }}.tar.gz"
 
 # The containerd download URL (normally no need to change it)
-containerd_url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/{{ containerd_archive }}"
+containerd_url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/{{ containerd_archive_base if containerd_flavor == 'base' else containerd_archive_k8s }}"
 
 # containerd systemd service settings
 containerd_service_settings:
   "ExecStartPre": "{{ modprobe_location }} overlay"
-  "ExecStart": "{{ containerd_bin_directory }}/containerd"
+  "ExecStart": "{{ containerd_binary_directory }}/containerd"
   "Restart": "always"
   "RestartSec": "5"
   "Delegate": "yes"
@@ -49,12 +96,376 @@ containerd_service_settings:
   "LimitNPROC": "infinity"
   "LimitCORE": "infinity"
 
-# containerd configuration
+# Content of configuration file of containerd. The settings below are the
+# default "containerd" settings generated with the following command (needs
+# "containerd" binary installed of course):
+#
+# containerd config default
+#
+# The configuration file contains a few role variables that will be replaced when
+# the configuration template is processed.
+#
 containerd_config: |
+  disabled_plugins = []
+  imports = []
+  oom_score = 0
+  plugin_dir = ""
+  required_plugins = []
+  root = "/var/lib/containerd"
+  state = "/run/containerd"
+  version = 2
+
+  [cgroup]
+    path = ""
+
+  [debug]
+    address = ""
+    format = ""
+    gid = 0
+    level = ""
+    uid = 0
+
+  [grpc]
+    address = "/run/containerd/containerd.sock"
+    gid = 0
+    max_recv_message_size = 16777216
+    max_send_message_size = 16777216
+    tcp_address = ""
+    tcp_tls_cert = ""
+    tcp_tls_key = ""
+    uid = 0
+
+  [metrics]
+    address = ""
+    grpc_histogram = false
+
   [plugins]
-    [plugins.cri.containerd]
-      snapshotter = "overlayfs"
-      [plugins.cri.containerd.default_runtime]
-        runtime_type = "io.containerd.runtime.v1.linux"
-        runtime_engine = "/usr/local/bin/runc"
-        runtime_root = ""
+
+    [plugins."io.containerd.gc.v1.scheduler"]
+      deletion_threshold = 0
+      mutation_threshold = 100
+      pause_threshold = 0.02
+      schedule_delay = "0s"
+      startup_delay = "100ms"
+
+    [plugins."io.containerd.grpc.v1.cri"]
+      disable_apparmor = false
+      disable_cgroup = false
+      disable_hugetlb_controller = true
+      disable_proc_mount = false
+      disable_tcp_service = true
+      enable_selinux = false
+      enable_tls_streaming = false
+      ignore_image_defined_volumes = false
+      max_concurrent_downloads = 3
+      max_container_log_line_size = 16384
+      netns_mounts_under_state_dir = false
+      restrict_oom_score_adj = false
+      sandbox_image = "k8s.gcr.io/pause:3.5"
+      selinux_category_range = 1024
+      stats_collect_period = 10
+      stream_idle_timeout = "4h0m0s"
+      stream_server_address = "127.0.0.1"
+      stream_server_port = "0"
+      systemd_cgroup = false
+      tolerate_missing_hugetlb_controller = true
+      unset_seccomp_profile = ""
+
+      [plugins."io.containerd.grpc.v1.cri".cni]
+        bin_dir = "{% if containerd_cni_binary_directory is defined %}{{ containerd_cni_binary_directory }}{% else %}/opt/cni/bin{% endif -%}"
+        conf_dir = "{% if containerd_cni_netconfig_directory is defined %}{{ containerd_cni_netconfig_directory }}{% else %}/etc/cni/net.d{% endif %}"
+        conf_template = ""
+        max_conf_num = 1
+
+      [plugins."io.containerd.grpc.v1.cri".containerd]
+        default_runtime_name = "runc"
+        disable_snapshot_annotations = true
+        discard_unpacked_layers = false
+        no_pivot = false
+        snapshotter = "overlayfs"
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+          base_runtime_spec = ""
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_root = ""
+          runtime_type = ""
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+            base_runtime_spec = ""
+            container_annotations = []
+            pod_annotations = []
+            privileged_without_host_devices = false
+            runtime_engine = ""
+            runtime_root = ""
+            runtime_type = "io.containerd.runc.v2"
+
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+              BinaryName = ""
+              CriuImagePath = ""
+              CriuPath = ""
+              CriuWorkPath = ""
+              IoGid = 0
+              IoUid = 0
+              NoNewKeyring = false
+              NoPivotRoot = false
+              Root = ""
+              ShimCgroup = ""
+              SystemdCgroup = false
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+          base_runtime_spec = ""
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_root = ""
+          runtime_type = ""
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".image_decryption]
+        key_model = "node"
+
+      [plugins."io.containerd.grpc.v1.cri".registry]
+        config_path = ""
+
+        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+      [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+        tls_cert_file = ""
+        tls_key_file = ""
+
+    [plugins."io.containerd.internal.v1.opt"]
+      path = "/opt/containerd"
+
+    [plugins."io.containerd.internal.v1.restart"]
+      interval = "10s"
+
+    [plugins."io.containerd.metadata.v1.bolt"]
+      content_sharing_policy = "shared"
+
+    [plugins."io.containerd.monitor.v1.cgroups"]
+      no_prometheus = false
+
+    [plugins."io.containerd.runtime.v1.linux"]
+      no_shim = false
+      runtime = "runc"
+      runtime_root = ""
+      shim = "containerd-shim"
+      shim_debug = false
+
+    [plugins."io.containerd.runtime.v2.task"]
+      platforms = ["linux/amd64"]
+
+    [plugins."io.containerd.service.v1.diff-service"]
+      default = ["walking"]
+
+    [plugins."io.containerd.snapshotter.v1.aufs"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.btrfs"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.devmapper"]
+      async_remove = false
+      base_image_size = ""
+      pool_name = ""
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.native"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.overlayfs"]
+      root_path = ""
+
+    [plugins."io.containerd.snapshotter.v1.zfs"]
+      root_path = ""
+
+  [proxy_plugins]
+
+  [stream_processors]
+
+    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+      accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+      args = ["--decryption-keys-path", "{{ containerd_config_directory }}/ocicrypt/keys"]
+      env = ["OCICRYPT_KEYPROVIDER_CONFIG={{ containerd_config_directory }}/ocicrypt/ocicrypt_keyprovider.conf"]
+      path = "ctd-decoder"
+      returns = "application/vnd.oci.image.layer.v1.tar"
+
+    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+      accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+      args = ["--decryption-keys-path", "{{ containerd_config_directory }}/ocicrypt/keys"]
+      env = ["OCICRYPT_KEYPROVIDER_CONFIG={{ containerd_config_directory }}/ocicrypt/ocicrypt_keyprovider.conf"]
+      path = "ctd-decoder"
+      returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+  [timeouts]
+    "io.containerd.timeout.shim.cleanup" = "5s"
+    "io.containerd.timeout.shim.load" = "5s"
+    "io.containerd.timeout.shim.shutdown" = "3s"
+    "io.containerd.timeout.task.state" = "2s"
+
+  [ttrpc]
+    address = ""
+    gid = 0
+    uid = 0
+
+
+#################################################
+# runc
+#################################################
+
+# Directory where to store the "runc" binary.
+#
+# As mentioned above if "containerd_flavor: base" was specified "runc" needs
+# to be installed seperately. Without a "runc" binary containerd won't work.
+#
+# Commented by default. If "runc" should be installed just remove the comment
+# and adjust the value if needed. But the default should be just fine.
+# As long as "containerd_runc_binary_directory" is commented all the other
+# "containerd_runc_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_runc_binary_directory: "/usr/local/sbin"
+
+# Owner/group of "runc" binary. If the variables are not set
+# the resulting binary will be owned by the current user.
+containerd_runc_owner: "root"
+containerd_runc_group: "root"
+
+# Specifies the permissions of the "runc" binary
+containerd_runc_binary_mode: "0755"
+
+
+#################################################
+# crictl
+#################################################
+
+# Configuration file for "crictl" (client for CRI).
+#
+# Commented by default. If "crictl" should be installed just remove the
+# comments and adjust the values if needed. But the defaults should be just fine.
+# As long as "containerd_crictl_config_(file|directory)" are commented all the other
+# "containerd_crictl_config_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_crictl_config_file: "crictl.yaml"
+# containerd_crictl_config_directory: "/etc"
+
+# Directory permissions for directory defined in "containerd_crictl_config_directory"
+# As the default for this directory is "/etc" be careful about permissions!
+# If this variable is not specified the default is "0755".
+containerd_crictl_config_directory_mode: "0755"
+
+# Owner/group of directory defined in "containerd_crictl_config_directory".
+# As the default for this directory is "/etc" be careful about ownership!
+# If these variables are not specified the default owner is "root" / group "root".
+containerd_crictl_config_directory_owner: "root"
+containerd_crictl_config_directory_group: "root"
+
+# Owner/group of "crictl.yaml". If the variables are not set
+# the resulting binary will be owned by the current user.
+containerd_crictl_config_file_owner: "root"
+containerd_crictl_config_file_group: "root"
+
+# Specifies the permissions of the "crictl.yaml" file.
+containerd_crictl_config_file_mode: "0644"
+
+containerd_crictl_config_file_content: |
+  runtime-endpoint: unix:///run/containerd/containerd.sock
+
+
+#################################################
+# CNI
+#################################################
+
+# Directory where to store the CNI binaries.
+#
+# Commented by default. If CNI binaries should be installed just remove the
+# comment and adjust the value if needed. But the default should be just fine.
+# As long as "containerd_cni_binary_directory" is commented all the other
+# "containerd_cni_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_cni_binary_directory: "/opt/cni/bin"
+
+# Directory permissions for directory containing CNI binaries
+containerd_cni_binary_directory_mode: "0755"
+
+# Owner/group of CNI binaries. If the variables are not set
+# the resulting binary will be owned by the current user.
+containerd_cni_binary_owner: "root"
+containerd_cni_binary_group: "root"
+
+# Specifies the permissions of the "CNI" files.
+containerd_cni_binary_mode: "0755"
+
+# Name of the CNI network configuration file and the directory where this file
+# should be placed.
+# These variables are commented by default which means that no CNI network
+# configuration file will be created. Some Kubernetes networking platforms like
+# "Cilium" are creating this file on the fly while starting up on a K8s node.
+# So in this case it's sufficient to only have the CNI binaries installed.
+# As long as "containerd_cni_netconfig_(file|directory)" are commented all the other
+# "containerd_cni_netconfig_*" variables have no effect. The same is true if
+# "containerd_flavor: base" is specified.
+# containerd_cni_netconfig_file: "10-containerd-net.conflist"
+# containerd_cni_netconfig_directory: "/etc/cni/net.d"
+
+# Directory permissions of network configuration directory
+containerd_cni_netconfig_directory_mode: "0755"
+
+# Owner/group of CNI network configuration file. If these variables are not set
+# the file will be owned by the current user.
+containerd_cni_netconfig_file_owner: "root"
+containerd_cni_netconfig_file_group: "root"
+
+# Specifies the permissions of the file specified in "containerd_cni_netconfig_file"
+containerd_cni_netconfig_file_mode: "0644"
+
+# Content of CNI network configuration file. This is only an example! Please
+# adjust to your needs! If this variable is commented the configuration file
+# specified in "containerd_cni_netconfig_file" won't be created.
+containerd_cni_netconfig_file_content: |
+  {
+    "cniVersion": "0.4.0",
+    "name": "containerd-net",
+    "plugins": [
+      {
+        "type": "bridge",
+        "bridge": "cni0",
+        "isGateway": true,
+        "ipMasq": true,
+        "promiscMode": true,
+        "ipam": {
+          "type": "host-local",
+          "ranges": [
+            [{
+              "subnet": "10.88.0.0/16"
+            }],
+            [{
+              "subnet": "2001:4860:4860::/64"
+            }]
+          ],
+          "routes": [
+            { "dst": "0.0.0.0/0" },
+            { "dst": "::/0" }
+          ]
+        }
+      },
+      {
+        "type": "portmap",
+        "capabilities": {"portMappings": true}
+      }
+    ]
+  }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ containerd_binary_mode: "0755"
 containerd_os: "linux"
 
 # Processor architecture "containerd" should run on.
-# Other possible values: "386","arm64","arm"
+# Other possible values: "arm64","arm"
 containerd_arch: "amd64"
 
 # Name of the archive file name

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -2,39 +2,19 @@
 # Copyright (C) 2021 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: all
+- hosts: base
   remote_user: vagrant
   become: true
-  gather_facts: true
-  tasks:
-    - block:
-      - name: (Archlinux) Init pacman
-        raw: |
-          pacman-key --init
-          pacman-key --populate archlinux
-        changed_when: false
-        ignore_errors: true
-
-      - name: (Archlinux) Update pacman cache
-        pacman:
-          update_cache: yes
-        changed_when: false
-      when: ansible_distribution|lower == 'archlinux'
-
-    - name: (Ubuntu) Update APT package cache
-      apt:
-        update_cache: "true"
-        cache_valid_time: 3600
-      when: ansible_distribution|lower == 'ubuntu'
-
-- hosts: all
-  remote_user: vagrant
-  become: true
-  gather_facts: true
   tasks:
     - name: Include runc role
       include_role:
         name: githubixx.runc
+
+- hosts: all
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
     - name: Include containerd role
       include_role:
         name: githubixx.containerd

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -32,6 +32,9 @@
   become: true
   gather_facts: true
   tasks:
+    - name: Include runc role
+      include_role:
+        name: githubixx.runc
     - name: Include containerd role
       include_role:
         name: githubixx.containerd

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -32,9 +32,6 @@
   become: true
   gather_facts: true
   tasks:
-    - name: Include runc role
-      include_role:
-        name: githubixx.runc
     - name: Include containerd role
       include_role:
         name: githubixx.containerd

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -17,27 +17,62 @@ driver:
       cpus: 2
 
 platforms:
-  - name: test-containerd-ubuntu2004
+  - name: test-cd-ubuntu2004-base
     box: generic/ubuntu2004
+    groups:
+      - ubuntu
+      - base
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 192.168.10.10
-  - name: test-containerd-ubuntu1804
-    box: generic/ubuntu1804
+  - name: test-cd-ubuntu2004-k8s-runc
+    box: generic/ubuntu2004
+    groups:
+      - ubuntu
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 192.168.10.20
-  - name: test-containerd-arch
-    box: archlinux/archlinux
+  - name: test-cd-ubuntu2004-k8s-runc-cni
+    box: generic/ubuntu2004
+    groups:
+      - ubuntu
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.80
+        ip: 192.168.10.30
+  - name: test-cd-ubuntu2004-k8s-runc-cni-crictl
+    box: generic/ubuntu2004
+    groups:
+      - ubuntu
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.40
+  - name: test-cd-ubuntu1804-k8s-runc-cni-crictl
+    box: generic/ubuntu1804
+    groups:
+      - ubuntu
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.50
+  - name: test-cd-arch-k8s-base
+    box: archlinux/archlinux
+    groups:
+      - archlinux
+      - base
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.60
 
 provisioner:
   name: ansible
@@ -46,6 +81,35 @@ provisioner:
     ansible_become: true
   log: true
   lint: yamllint . && flake8 && ansible-lint
+  inventory:
+    host_vars:
+      test-cd-ubuntu2004-base:
+        runc_bin_directory: "/usr/local/sbin"
+        containerd_runc_binary_directory: "{{ runc_bin_directory }}"
+      test-cd-arch-k8s-base:
+        runc_bin_directory: "/usr/local/sbin"
+        containerd_runc_binary_directory: "{{ runc_bin_directory }}"
+      test-cd-ubuntu2004-k8s-runc:
+        containerd_flavor: "k8s"
+        containerd_runc_binary_directory: "/usr/local/sbin"
+      test-cd-ubuntu2004-k8s-runc-cni:
+        containerd_flavor: "k8s"
+        containerd_runc_binary_directory: "/usr/local/sbin"
+        containerd_cni_binary_directory: "/opt/cni/bin"
+      test-cd-ubuntu2004-k8s-runc-cni-crictl:
+        containerd_flavor: "k8s"
+        containerd_runc_binary_directory: "/usr/local/sbin"
+        containerd_cni_binary_directory: "/opt/cni/bin"
+        containerd_crictl_config_file: "crictl.yaml"
+        containerd_crictl_config_directory: "/etc"
+      test-cd-ubuntu1804-k8s-runc-cni-crictl:
+        containerd_flavor: "k8s"
+        containerd_runc_binary_directory: "/usr/local/sbin"
+        containerd_cni_binary_directory: "/opt/cni/bin"
+        containerd_crictl_config_file: "crictl.yaml"
+        containerd_crictl_config_directory: "/etc"
+        containerd_cni_netconfig_file: "10-containerd-net.conflist"
+        containerd_cni_netconfig_directory: "/etc/cni/net.d"
 
 scenario:
   name: kvm

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -1,0 +1,29 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: archlinux
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Init pacman
+      raw: |
+        pacman-key --init
+        pacman-key --populate archlinux
+      changed_when: false
+      failed_when: false
+
+    - name: Update pacman cache
+      pacman:
+        update_cache: true
+
+- hosts: ubuntu
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Update APT package cache
+      apt:
+        update_cache: true
+        cache_valid_time: 3600

--- a/molecule/kvm/requirements.yml
+++ b/molecule/kvm/requirements.yml
@@ -1,6 +1,0 @@
----
-# Copyright (C) 2021 Robert Wimmer
-# SPDX-License-Identifier: GPL-3.0-or-later
-
-roles:
-  - githubixx.runc

--- a/molecule/kvm/requirements.yml
+++ b/molecule/kvm/requirements.yml
@@ -1,0 +1,6 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+roles:
+  - githubixx.runc

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,71 +2,85 @@
 # Copyright (C) 2021 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Include variables depending on flavor
+  include_vars:
+    file: "flavor_{{ containerd_flavor }}.yml"
+  tags:
+    - containerd-install
+
 - name: Downloading containerd archive
   get_url:
     url: "{{ containerd_url }}"
-    dest: "{{ containerd_tmp_directory }}/{{ containerd_archive }}"
+    dest: "{{ containerd_tmp_directory }}/containerd.tar.gz"
     checksum: "sha256:{{ containerd_url }}.sha256sum"
   tags:
+    - containerd-install
     - containerd-download
 
 - name: Unarchive containerd
   unarchive:
-    src: "{{ containerd_tmp_directory }}/{{ containerd_archive }}"
+    src: "{{ containerd_tmp_directory }}/containerd.tar.gz"
     dest: "{{ containerd_tmp_directory }}"
     remote_src: true
   tags:
+    - containerd-install
     - containerd-unarchive
 
-- name: Copy containerd binary to destination directory
+- name: Copy containerd binaries to destination directory
   copy:
-    src: "{{ containerd_tmp_directory }}/bin/{{ item }}"
-    dest: "{{ containerd_bin_directory }}/{{ item }}"
+    src: "{{ containerd_tmp_directory }}{{ containerd_binaries_src_directory }}/{{ binary }}"
+    dest: "{{ containerd_binary_directory }}/{{ binary }}"
     mode: "{{ containerd_binary_mode }}"
     owner: "{{ containerd_owner | default(omit) }}"
     group: "{{ containerd_group | default(omit) }}"
     remote_src: true
-  with_items:
-    - containerd-shim-runc-v1
-    - ctr
-    - containerd-shim
-    - containerd
-    - containerd-shim-runc-v2
+  loop: "{{ containerd_binaries }}"
+  loop_control:
+    loop_var: "binary"
   tags:
     - containerd-install
 
 - name: Create directory for containerd configuration file
   file:
-    path: "{{ containerd_conf_directory }}"
+    path: "{{ containerd_config_directory }}"
     state: directory
     mode: 0755
     owner: root
     group: root
   tags:
+    - containerd_install
     - containerd-config
 
 - name: Create containerd configuration file
   copy:
     content: "{{ containerd_config }}"
-    dest: /etc/containerd/config.toml
+    dest: "{{ containerd_config_directory }}/config.toml"
     owner: root
     group: root
     mode: 0644
   notify:
     - restart containerd
   tags:
+    - containerd_install
     - containerd-config
 
 - name: Find location of modprobe binary
   set_fact:
-    modprobe_location: "{{ lookup('first_found', item + '/modprobe', errors='ignore') }}"
+    modprobe_location: "{{ lookup('first_found', modprobe_path + '/modprobe', errors='ignore') }}"
   loop:
     - /usr/bin
+    - /usr/sbin
     - /sbin
+  loop_control:
+    loop_var: "modprobe_path"
+  tags:
+    - containerd_install
 
 - name: modprobe path
   debug:
     msg: "Using {{ modprobe_location }} in containerd.service"
+  tags:
+    - containerd_install
 
 - name: Create containerd.service systemd file
   template:
@@ -79,7 +93,128 @@
     - reload systemd
     - restart containerd
   tags:
+    - containerd-install
     - containerd-systemd
+
+- name: Copy runc binary to destination directory
+  copy:
+    src: "{{ containerd_tmp_directory }}/usr/local/sbin/runc"
+    dest: "{{ containerd_runc_binary_directory }}/runc"
+    mode: "{{ containerd_runc_binary_mode }}"
+    owner: "{{ containerd_runc_owner | default(omit) }}"
+    group: "{{ containerd_runc_group | default(omit) }}"
+    remote_src: true
+  tags:
+    - runc-install
+  when:
+    - containerd_flavor is defined
+    - containerd_flavor == "k8s"
+    - containerd_runc_binary_directory is defined
+    - containerd_runc_binary_mode is defined
+
+- name: Ensure crictl configuration directory
+  file:
+    path: "{{ containerd_crictl_config_directory }}"
+    state: directory
+    mode: "{{ containerd_crictl_config_directory_mode | default('0755') }}"
+    owner: "{{ containerd_crictl_config_directory_owner | default('root') }}"
+    group: "{{ containerd_crictl_config_directory_group | default('root') }}"
+  when:
+    - containerd_flavor is defined
+    - containerd_flavor == "k8s"
+    - containerd_crictl_config_directory is defined
+    - containerd_crictl_config_owner is defined
+    - containerd_crictl_config_group is defined
+  tags:
+    - containerd-crictl-install
+
+- name: Copy crictl configuration to destination directory
+  copy:
+    content: |
+      {{ containerd_crictl_config_file_content }}
+    dest: "{{ containerd_crictl_config_directory }}/{{ containerd_crictl_config_file }}"
+    mode: "{{ containerd_crictl_config_file_mode | default('0644') }}"
+    owner: "{{ containerd_crictl_config_file_owner | default(omit) }}"
+    group: "{{ containerd_crictl_config_file_group | default(omit) }}"
+  when:
+    - containerd_flavor is defined
+    - containerd_flavor == "k8s"
+    - containerd_crictl_config_directory is defined
+    - containerd_crictl_config_file is defined
+    - containerd_crictl_config_file_mode is defined
+  tags:
+    - containerd-crictl-install
+
+- name: Ensure CNI bin directory
+  file:
+    path: "{{ containerd_cni_binary_directory }}"
+    state: directory
+    mode: "{{ containerd_cni_binary_directory_mode }}"
+    owner: "{{ containerd_cni_binary_owner | default(omit) }}"
+    group: "{{ containerd_cni_binary_group | default(omit) }}"
+  when:
+    - containerd_flavor is defined
+    - containerd_flavor == "k8s"
+    - containerd_cni_binary_directory is defined
+    - containerd_cni_binary_owner is defined
+    - containerd_cni_binary_group is defined
+  tags:
+    - containerd-cni-install
+
+- name: Copy CNI binaries to destination directory
+  copy:
+    src: "{{ containerd_tmp_directory }}/opt/cni/bin/{{ cni_binary }}"
+    dest: "{{ containerd_cni_binary_directory }}/{{ cni_binary }}"
+    mode: "{{ containerd_cni_binary_mode }}"
+    owner: "{{ containerd_cni_binary_owner | default(omit) }}"
+    group: "{{ containerd_cni_binary_group | default(omit) }}"
+    remote_src: true
+  loop: "{{ containerd_cni_binaries }}"
+  loop_control:
+    loop_var: "cni_binary"
+  when:
+    - containerd_flavor is defined
+    - containerd_flavor == "k8s"
+    - containerd_cni_binary_directory is defined
+    - containerd_cni_binary_owner is defined
+    - containerd_cni_binary_group is defined
+  tags:
+    - containerd-cni-install
+
+- name: Ensure CNI netconfig directory
+  file:
+    path: "{{ containerd_cni_netconfig_directory }}"
+    state: directory
+    mode: "{{ containerd_cni_netconfig_directory_mode | default('0755') }}"
+    owner: "{{ containerd_cni_netconfig_owner | default(omit) }}"
+    group: "{{ containerd_cni_netconfig_group | default(omit) }}"
+  when:
+    - containerd_flavor is defined
+    - containerd_flavor == "k8s"
+    - containerd_cni_netconfig_file is defined
+    - containerd_cni_netconfig_directory is defined
+    - containerd_cni_netconfig_file_content is defined
+  tags:
+    - containerd-cni-install
+    - containerd-cni-conf
+
+- name: Copy CNI netconfig to destination directory
+  copy:
+    content: |
+      {{ containerd_cni_netconfig_file_content }}
+    dest: "{{ containerd_cni_netconfig_directory }}/{{ containerd_cni_netconfig_file }}"
+    mode: "{{ containerd_cni_netconfig_file_mode | default('0644') }}"
+    owner: "{{ containerd_cni_netconfig_file_owner | default(omit) }}"
+    group: "{{ containerd_cni_netconfig_file_group | default(omit) }}"
+  when:
+    - containerd_flavor is defined
+    - containerd_flavor == "k8s"
+    - containerd_cni_netconfig_file is defined
+    - containerd_cni_netconfig_directory is defined
+    - containerd_cni_netconfig_file_content is defined
+  tags:
+    - containerd-cni-install
+    - containerd-cni-conf
 
 - name: Flush handlers
   meta: flush_handlers

--- a/templates/etc/systemd/system/containerd.service.j2
+++ b/templates/etc/systemd/system/containerd.service.j2
@@ -7,7 +7,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target
+After=network.target local-fs.target
 
 [Service]
 {%- for setting in containerd_service_settings|sort %}

--- a/vars/flavor_base.yml
+++ b/vars/flavor_base.yml
@@ -1,0 +1,12 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+containerd_binaries_src_directory: "/bin"
+
+containerd_binaries:
+  - containerd
+  - containerd-shim
+  - containerd-shim-runc-v1
+  - containerd-shim-runc-v2
+  - ctr

--- a/vars/flavor_k8s.yml
+++ b/vars/flavor_k8s.yml
@@ -1,0 +1,32 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+containerd_binaries_src_directory: "/usr/local/bin"
+
+containerd_binaries:
+  - containerd
+  - containerd-shim
+  - containerd-shim-runc-v1
+  - containerd-shim-runc-v2
+  - crictl
+  - critest
+  - ctr
+
+containerd_cni_binaries:
+  - bandwidth
+  - bridge
+  - dhcp
+  - firewall
+  - flannel
+  - host-device
+  - host-local
+  - ipvlan
+  - loopback
+  - macvlan
+  - portmap
+  - ptp
+  - sbr
+  - static
+  - tuning
+  - vlan


### PR DESCRIPTION
Add support for Kubernetes by allowing to optionally also install `runc`, `crtcl` and `CNI` plugins. `containerd` builds are available in two flavors: Either just the `containerd` binaries or `containerd` binaries plus everything else needed to use `containerd` together with Kubernetes. Please see [defaults/main.yml](https://github.com/githubixx/ansible-role-containerd/tree/master/defaults/main.yml) for all possible settings. With the Kubernetes support a lot of new variables were introduced but for almost all the default values should be good enough. The default `containerd_flavor: "base"` mimics the behavior of the previous version of this role. So upgrading shouldn't be an issue.