### PR TITLE
Allow runc to be on non-standard directories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -213,7 +213,7 @@ containerd_config: |
             runtime_type = "io.containerd.runc.v2"
 
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              BinaryName = ""
+              BinaryName = "{% if containerd_runc_binary_directory is defined %}{{ containerd_runc_binary_directory }}/runc{% endif -%}"
               CriuImagePath = ""
               CriuPath = ""
               CriuWorkPath = ""


### PR DESCRIPTION
The previous configuration required the `runc` directory be on `PATH`. However, since the `runc`
directory is customizable by the `containerd_runc_binary_directory` there's a chance that's not
valid. Now, if the `runc` directory is specified, the its path will be set in the `containerd`
options.