### PR TITLE
Fix modprobe location resolution

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,14 +65,21 @@
     - containerd-config
 
 - name: Find location of modprobe binary
-  set_fact:
-    modprobe_location: "{{ lookup('first_found', modprobe_path + '/modprobe', errors='ignore') }}"
+  ansible.builtin.stat:
+    path: "{{ path }}"
   loop:
-    - /usr/bin
-    - /usr/sbin
-    - /sbin
+    - /usr/bin/modprobe
+    - /usr/sbin/modprobe
+    - /sbin/modprobe
   loop_control:
-    loop_var: "modprobe_path"
+    loop_var: path
+  register: modprobe_locations
+  tags:
+    - containerd_install
+
+- name: Set modprobe_location
+  ansible.builtin.set_fact:
+    modprobe_location: "{{ modprobe_locations.results | selectattr('stat.exists', '==', True) | map(attribute='path') | first }}"
   tags:
     - containerd_install
 


### PR DESCRIPTION
Ansible's `first_found` lookup plugin runs in the controller host, not in the remote hosts.
Therefore, if the `modprobe` location in the target host is not the same as on the remote host,
the role fails silently since it does not find the `modprobe` binary and creates a syntax error
in the systemd unit file.

This approach uses `stat` instead to probe for the `modprobe` binary in various locations and then
selects the first found. This has the added benefit of failing when the binary is not found in the
remote host since the `first` filter fails when the list is empty.