### PR TITLE
update containerd to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0+1.6.0
+
+- update `containerd` to 'v1.6.0`
+- update `containerd_config` variable value for containerd `v.1.6.0`
+
 ## 0.4.0+1.5.9
 
 - The `BinaryName` value in `container_config` variable will now use the value of `containerd_runc_binary_directory` if defined by default. (contribution by @tiagoblackcode)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Role Variables
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.5.9"
+containerd_version: "1.6.0"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ containerd_config: |
   required_plugins = []
   root = "/var/lib/containerd"
   state = "/run/containerd"
+  temp = ""
   version = 2
 
   [cgroup]
@@ -152,6 +153,7 @@ containerd_config: |
     max_recv_message_size = 16777216
     max_send_message_size = 16777216
     tcp_address = ""
+    tcp_tls_ca = ""
     tcp_tls_cert = ""
     tcp_tls_key = ""
     uid = 0
@@ -170,6 +172,7 @@ containerd_config: |
       startup_delay = "100ms"
 
     [plugins."io.containerd.grpc.v1.cri"]
+      device_ownership_from_security_context = false
       disable_apparmor = false
       disable_cgroup = false
       disable_hugetlb_controller = true
@@ -177,12 +180,14 @@ containerd_config: |
       disable_tcp_service = true
       enable_selinux = false
       enable_tls_streaming = false
+      enable_unprivileged_icmp = false
+      enable_unprivileged_ports = false
       ignore_image_defined_volumes = false
       max_concurrent_downloads = 3
       max_container_log_line_size = 16384
       netns_mounts_under_state_dir = false
       restrict_oom_score_adj = false
-      sandbox_image = "k8s.gcr.io/pause:3.5"
+      sandbox_image = "k8s.gcr.io/pause:3.6"
       selinux_category_range = 1024
       stats_collect_period = 10
       stream_idle_timeout = "4h0m0s"
@@ -196,21 +201,26 @@ containerd_config: |
         bin_dir = "{% if containerd_cni_binary_directory is defined %}{{ containerd_cni_binary_directory }}{% else %}/opt/cni/bin{% endif -%}"
         conf_dir = "{% if containerd_cni_netconfig_directory is defined %}{{ containerd_cni_netconfig_directory }}{% else %}/etc/cni/net.d{% endif %}"
         conf_template = ""
+        ip_pref = ""
         max_conf_num = 1
 
       [plugins."io.containerd.grpc.v1.cri".containerd]
         default_runtime_name = "runc"
         disable_snapshot_annotations = true
         discard_unpacked_layers = false
+        ignore_rdt_not_enabled_errors = false
         no_pivot = false
         snapshotter = "overlayfs"
 
         [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
           base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
           container_annotations = []
           pod_annotations = []
           privileged_without_host_devices = false
           runtime_engine = ""
+          runtime_path = ""
           runtime_root = ""
           runtime_type = ""
 
@@ -220,10 +230,13 @@ containerd_config: |
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
             base_runtime_spec = ""
+            cni_conf_dir = ""
+            cni_max_conf_num = 0
             container_annotations = []
             pod_annotations = []
             privileged_without_host_devices = false
             runtime_engine = ""
+            runtime_path = ""
             runtime_root = ""
             runtime_type = "io.containerd.runc.v2"
 
@@ -242,10 +255,13 @@ containerd_config: |
 
         [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
           base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
           container_annotations = []
           pod_annotations = []
           privileged_without_host_devices = false
           runtime_engine = ""
+          runtime_path = ""
           runtime_root = ""
           runtime_type = ""
 
@@ -275,6 +291,10 @@ containerd_config: |
     [plugins."io.containerd.internal.v1.restart"]
       interval = "10s"
 
+    [plugins."io.containerd.internal.v1.tracing"]
+      sampling_ratio = 1.0
+      service_name = "containerd"
+
     [plugins."io.containerd.metadata.v1.bolt"]
       content_sharing_policy = "shared"
 
@@ -290,9 +310,13 @@ containerd_config: |
 
     [plugins."io.containerd.runtime.v2.task"]
       platforms = ["linux/amd64"]
+      sched_core = false
 
     [plugins."io.containerd.service.v1.diff-service"]
       default = ["walking"]
+
+    [plugins."io.containerd.service.v1.tasks-service"]
+      rdt_config_file = ""
 
     [plugins."io.containerd.snapshotter.v1.aufs"]
       root_path = ""
@@ -303,6 +327,9 @@ containerd_config: |
     [plugins."io.containerd.snapshotter.v1.devmapper"]
       async_remove = false
       base_image_size = ""
+      discard_blocks = false
+      fs_options = ""
+      fs_type = ""
       pool_name = ""
       root_path = ""
 
@@ -311,9 +338,15 @@ containerd_config: |
 
     [plugins."io.containerd.snapshotter.v1.overlayfs"]
       root_path = ""
+      upperdir_label = false
 
     [plugins."io.containerd.snapshotter.v1.zfs"]
       root_path = ""
+
+    [plugins."io.containerd.tracing.processor.v1.otlp"]
+      endpoint = ""
+      insecure = false
+      protocol = ""
 
   [proxy_plugins]
 
@@ -334,6 +367,7 @@ containerd_config: |
       returns = "application/vnd.oci.image.layer.v1.tar+gzip"
 
   [timeouts]
+    "io.containerd.timeout.bolt.open" = "0s"
     "io.containerd.timeout.shim.cleanup" = "5s"
     "io.containerd.timeout.shim.load" = "5s"
     "io.containerd.timeout.shim.shutdown" = "3s"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.5.9"
+containerd_version: "1.6.0"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"
@@ -119,6 +119,7 @@ containerd_config: |
   required_plugins = []
   root = "/var/lib/containerd"
   state = "/run/containerd"
+  temp = ""
   version = 2
 
   [cgroup]
@@ -137,6 +138,7 @@ containerd_config: |
     max_recv_message_size = 16777216
     max_send_message_size = 16777216
     tcp_address = ""
+    tcp_tls_ca = ""
     tcp_tls_cert = ""
     tcp_tls_key = ""
     uid = 0
@@ -155,6 +157,7 @@ containerd_config: |
       startup_delay = "100ms"
 
     [plugins."io.containerd.grpc.v1.cri"]
+      device_ownership_from_security_context = false
       disable_apparmor = false
       disable_cgroup = false
       disable_hugetlb_controller = true
@@ -162,12 +165,14 @@ containerd_config: |
       disable_tcp_service = true
       enable_selinux = false
       enable_tls_streaming = false
+      enable_unprivileged_icmp = false
+      enable_unprivileged_ports = false
       ignore_image_defined_volumes = false
       max_concurrent_downloads = 3
       max_container_log_line_size = 16384
       netns_mounts_under_state_dir = false
       restrict_oom_score_adj = false
-      sandbox_image = "k8s.gcr.io/pause:3.5"
+      sandbox_image = "k8s.gcr.io/pause:3.6"
       selinux_category_range = 1024
       stats_collect_period = 10
       stream_idle_timeout = "4h0m0s"
@@ -181,21 +186,26 @@ containerd_config: |
         bin_dir = "{% if containerd_cni_binary_directory is defined %}{{ containerd_cni_binary_directory }}{% else %}/opt/cni/bin{% endif -%}"
         conf_dir = "{% if containerd_cni_netconfig_directory is defined %}{{ containerd_cni_netconfig_directory }}{% else %}/etc/cni/net.d{% endif %}"
         conf_template = ""
+        ip_pref = ""
         max_conf_num = 1
 
       [plugins."io.containerd.grpc.v1.cri".containerd]
         default_runtime_name = "runc"
         disable_snapshot_annotations = true
         discard_unpacked_layers = false
+        ignore_rdt_not_enabled_errors = false
         no_pivot = false
         snapshotter = "overlayfs"
 
         [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
           base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
           container_annotations = []
           pod_annotations = []
           privileged_without_host_devices = false
           runtime_engine = ""
+          runtime_path = ""
           runtime_root = ""
           runtime_type = ""
 
@@ -205,10 +215,13 @@ containerd_config: |
 
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
             base_runtime_spec = ""
+            cni_conf_dir = ""
+            cni_max_conf_num = 0
             container_annotations = []
             pod_annotations = []
             privileged_without_host_devices = false
             runtime_engine = ""
+            runtime_path = ""
             runtime_root = ""
             runtime_type = "io.containerd.runc.v2"
 
@@ -227,10 +240,13 @@ containerd_config: |
 
         [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
           base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
           container_annotations = []
           pod_annotations = []
           privileged_without_host_devices = false
           runtime_engine = ""
+          runtime_path = ""
           runtime_root = ""
           runtime_type = ""
 
@@ -260,6 +276,10 @@ containerd_config: |
     [plugins."io.containerd.internal.v1.restart"]
       interval = "10s"
 
+    [plugins."io.containerd.internal.v1.tracing"]
+      sampling_ratio = 1.0
+      service_name = "containerd"
+
     [plugins."io.containerd.metadata.v1.bolt"]
       content_sharing_policy = "shared"
 
@@ -275,9 +295,13 @@ containerd_config: |
 
     [plugins."io.containerd.runtime.v2.task"]
       platforms = ["linux/amd64"]
+      sched_core = false
 
     [plugins."io.containerd.service.v1.diff-service"]
       default = ["walking"]
+
+    [plugins."io.containerd.service.v1.tasks-service"]
+      rdt_config_file = ""
 
     [plugins."io.containerd.snapshotter.v1.aufs"]
       root_path = ""
@@ -288,6 +312,9 @@ containerd_config: |
     [plugins."io.containerd.snapshotter.v1.devmapper"]
       async_remove = false
       base_image_size = ""
+      discard_blocks = false
+      fs_options = ""
+      fs_type = ""
       pool_name = ""
       root_path = ""
 
@@ -296,9 +323,15 @@ containerd_config: |
 
     [plugins."io.containerd.snapshotter.v1.overlayfs"]
       root_path = ""
+      upperdir_label = false
 
     [plugins."io.containerd.snapshotter.v1.zfs"]
       root_path = ""
+
+    [plugins."io.containerd.tracing.processor.v1.otlp"]
+      endpoint = ""
+      insecure = false
+      protocol = ""
 
   [proxy_plugins]
 
@@ -319,6 +352,7 @@ containerd_config: |
       returns = "application/vnd.oci.image.layer.v1.tar+gzip"
 
   [timeouts]
+    "io.containerd.timeout.bolt.open" = "0s"
     "io.containerd.timeout.shim.cleanup" = "5s"
     "io.containerd.timeout.shim.load" = "5s"
     "io.containerd.timeout.shim.shutdown" = "3s"

--- a/vars/flavor_k8s.yml
+++ b/vars/flavor_k8s.yml
@@ -29,3 +29,4 @@ containerd_cni_binaries:
   - static
   - tuning
   - vlan
+  - vrf

--- a/vars/flavor_k8s.yml
+++ b/vars/flavor_k8s.yml
@@ -18,7 +18,6 @@ containerd_cni_binaries:
   - bridge
   - dhcp
   - firewall
-  - flannel
   - host-device
   - host-local
   - ipvlan


### PR DESCRIPTION
- update `containerd` to 'v1.6.0`
- update `containerd_config` variable value for containerd `v.1.6.0`
- `flannel` no longer part of CNI archive
- add `vrf` CNI binary to `containerd_cni_binaries`