### PR TITLE
0.6.0+1.6.8

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 200
+    level: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.0+1.6.8
+
+- fix file permissions in task `Downloading containerd archive`
+- ansible-lint: fix issues
+- `min_ansible_version` in `meta/main.yml` value should be string
+- add `.yamllit`
+
 ## 0.5.5+1.6.8
 
 - update `containerd` to 'v1.6.8`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,7 @@ containerd_binary_directory: "/usr/local/bin"
 containerd_config_directory: "/etc/containerd"
 
 # Directory to store the archive
-containerd_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
+containerd_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}"
 
 # Owner/group of "containerd" binaries. If the variables are not set
 # the resulting binary will be owned by the current user.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,11 +2,11 @@
 # Copyright (C) 2021 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: reload systemd
-  systemd:
+- name: Reload systemd
+  ansible.builtin.systemd:
     daemon_reload: true
 
-- name: restart containerd
-  systemd:
+- name: Restart containerd
+  ansible.builtin.systemd:
     name: containerd
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   author: Robert Wimmer
   description: Ansible role to install containerd
   license: GPLv3
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   role_name: containerd
   namespace: githubixx
   platforms:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,7 +83,7 @@
   tags:
     - containerd_install
 
-- name: modprobe path
+- name: Modprobe path
   ansible.builtin.debug:
     msg: "Using {{ modprobe_location }} in containerd.service"
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
     group: root
     mode: 0644
   notify:
-    - restart containerd
+    - Restart containerd
   tags:
     - containerd_install
     - containerd-config
@@ -97,8 +97,8 @@
     group: root
     mode: 0644
   notify:
-    - reload systemd
-    - restart containerd
+    - Reload systemd
+    - Restart containerd
   tags:
     - containerd-install
     - containerd-systemd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
     url: "{{ containerd_url }}"
     dest: "{{ containerd_tmp_directory }}/containerd.tar.gz"
     checksum: "sha256:{{ containerd_url }}.sha256sum"
+    mode: 0600
   tags:
     - containerd-install
     - containerd-download

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Include variables depending on flavor
-  include_vars:
+  ansible.builtin.include_vars:
     file: "flavor_{{ containerd_flavor }}.yml"
   tags:
     - containerd-install
 
 - name: Downloading containerd archive
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ containerd_url }}"
     dest: "{{ containerd_tmp_directory }}/containerd.tar.gz"
     checksum: "sha256:{{ containerd_url }}.sha256sum"
@@ -18,7 +18,7 @@
     - containerd-download
 
 - name: Unarchive containerd
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ containerd_tmp_directory }}/containerd.tar.gz"
     dest: "{{ containerd_tmp_directory }}"
     remote_src: true
@@ -27,7 +27,7 @@
     - containerd-unarchive
 
 - name: Copy containerd binaries to destination directory
-  copy:
+  ansible.builtin.copy:
     src: "{{ containerd_tmp_directory }}{{ containerd_binaries_src_directory }}/{{ binary }}"
     dest: "{{ containerd_binary_directory }}/{{ binary }}"
     mode: "{{ containerd_binary_mode }}"
@@ -41,7 +41,7 @@
     - containerd-install
 
 - name: Create directory for containerd configuration file
-  file:
+  ansible.builtin.file:
     path: "{{ containerd_config_directory }}"
     state: directory
     mode: 0755
@@ -52,7 +52,7 @@
     - containerd-config
 
 - name: Create containerd configuration file
-  copy:
+  ansible.builtin.copy:
     content: "{{ containerd_config }}"
     dest: "{{ containerd_config_directory }}/config.toml"
     owner: root
@@ -84,13 +84,13 @@
     - containerd_install
 
 - name: modprobe path
-  debug:
+  ansible.builtin.debug:
     msg: "Using {{ modprobe_location }} in containerd.service"
   tags:
     - containerd_install
 
 - name: Create containerd.service systemd file
-  template:
+  ansible.builtin.template:
     src: etc/systemd/system/containerd.service.j2
     dest: /etc/systemd/system/containerd.service
     owner: root
@@ -104,7 +104,7 @@
     - containerd-systemd
 
 - name: Copy runc binary to destination directory
-  copy:
+  ansible.builtin.copy:
     src: "{{ containerd_tmp_directory }}/usr/local/sbin/runc"
     dest: "{{ containerd_runc_binary_directory }}/runc"
     mode: "{{ containerd_runc_binary_mode }}"
@@ -120,7 +120,7 @@
     - containerd_runc_binary_mode is defined
 
 - name: Ensure crictl configuration directory
-  file:
+  ansible.builtin.file:
     path: "{{ containerd_crictl_config_directory }}"
     state: directory
     mode: "{{ containerd_crictl_config_directory_mode | default('0755') }}"
@@ -136,7 +136,7 @@
     - containerd-crictl-install
 
 - name: Copy crictl configuration to destination directory
-  copy:
+  ansible.builtin.copy:
     content: |
       {{ containerd_crictl_config_file_content }}
     dest: "{{ containerd_crictl_config_directory }}/{{ containerd_crictl_config_file }}"
@@ -153,7 +153,7 @@
     - containerd-crictl-install
 
 - name: Ensure CNI bin directory
-  file:
+  ansible.builtin.file:
     path: "{{ containerd_cni_binary_directory }}"
     state: directory
     mode: "{{ containerd_cni_binary_directory_mode }}"
@@ -169,7 +169,7 @@
     - containerd-cni-install
 
 - name: Copy CNI binaries to destination directory
-  copy:
+  ansible.builtin.copy:
     src: "{{ containerd_tmp_directory }}/opt/cni/bin/{{ cni_binary }}"
     dest: "{{ containerd_cni_binary_directory }}/{{ cni_binary }}"
     mode: "{{ containerd_cni_binary_mode }}"
@@ -189,7 +189,7 @@
     - containerd-cni-install
 
 - name: Ensure CNI netconfig directory
-  file:
+  ansible.builtin.file:
     path: "{{ containerd_cni_netconfig_directory }}"
     state: directory
     mode: "{{ containerd_cni_netconfig_directory_mode | default('0755') }}"
@@ -206,7 +206,7 @@
     - containerd-cni-conf
 
 - name: Copy CNI netconfig to destination directory
-  copy:
+  ansible.builtin.copy:
     content: |
       {{ containerd_cni_netconfig_file_content }}
     dest: "{{ containerd_cni_netconfig_directory }}/{{ containerd_cni_netconfig_file }}"
@@ -224,10 +224,10 @@
     - containerd-cni-conf
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: Enable and start containerd
-  service:
+  ansible.builtin.service:
     name: containerd
     enabled: true
     state: started


### PR DESCRIPTION
- fix file permissions in task `Downloading containerd archive`
- ansible-lint: fix issues
- `min_ansible_version` in `meta/main.yml` value should be string
- add `.yamllit`