### PR TITLE
0.10.0+1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - update `containerd` to 'v1.7.3`
 - add support for Ubuntu 22.04
 - **BREAKING**: remove support for Ubuntu 18.04 (reached end of life)
-- **BREAKING**: When `containerd` or `CNI` binaries are upgraded `containerd.service` will be restarted. Up until this version this only happened when `containerd` configuration was updated. 
+- **BREAKING**: When `containerd` or `CNI` binaries are upgraded `containerd.service` will be restarted. Up until this version this only happened when `containerd` configuration was updated.
 
 ## 0.9.0+1.7.0
 
@@ -34,7 +34,7 @@
 - fix file permissions in task `Downloading containerd archive`
 - ansible-lint: fix issues
 - `min_ansible_version` in `meta/main.yml` value should be string
-- add `.yamllit`
+- add `.yamllint`
 
 ## 0.5.5+1.6.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.10.0+1.7.3
 
 - update `containerd` to 'v1.7.3`
+- add support for Ubuntu 22.04
+- **BREAKING**: remove support for Ubuntu 18.04 (reached end of life)
 - **BREAKING**: When `containerd` or `CNI` binaries are upgraded `containerd.service` will be restarted. Up until this version this only happened when `containerd` configuration was updated. 
 
 ## 0.9.0+1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1+1.7.3
+
+- update `containerd` to 'v1.7.3`
+
 ## 0.9.0+1.7.0
 
 - update `containerd` to 'v1.7.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.9.1+1.7.3
+## 0.10.0+1.7.3
 
 - update `containerd` to 'v1.7.3`
+- **BREAKING**: When `containerd` or `CNI` binaries are upgraded `containerd.service` will be restarted. Up until this version this only happened when `containerd` configuration was updated. 
 
 ## 0.9.0+1.7.0
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Role Variables
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.7.0"
+containerd_version: "1.7.3"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -555,6 +555,12 @@ molecule converge -s kvm
 
 This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `containerd` and optionally `runc`, `crictl` and the `CNI` plugins (which are needed by Kubernetes e.g.).
 
+A small verification step is also included. It pulls a nginx container and runs it to make sure that `containerd` is setup correctly and is able to run container images:
+
+```bash
+molecule verify -s kvm
+```
+
 To clean up run
 
 ```bash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.7.0"
+containerd_version: "1.7.3"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,8 +13,8 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - bionic
-        - focal
+        - "focal"
+        - "jammy"
   galaxy_tags:
     - kubernetes
     - k8s

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -2,19 +2,21 @@
 # Copyright (C) 2021 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: base
+- name: Install runc
+  hosts: base
   remote_user: vagrant
   become: true
   tasks:
     - name: Include runc role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.runc
 
-- hosts: all
+- name: Install containerd
+  hosts: all
   remote_user: vagrant
   become: true
   gather_facts: true
   tasks:
     - name: Include containerd role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.containerd

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -12,13 +12,12 @@ driver:
   provider:
     name: libvirt
     type: libvirt
-    options:
-      memory: 192
-      cpus: 2
 
 platforms:
   - name: test-cd-ubuntu2004-base
     box: generic/ubuntu2004
+    memory: 1024
+    cpus: 2
     groups:
       - ubuntu
       - base
@@ -29,6 +28,8 @@ platforms:
         ip: 192.168.10.10
   - name: test-cd-ubuntu2004-k8s-runc
     box: generic/ubuntu2004
+    memory: 1024
+    cpus: 2
     groups:
       - ubuntu
     interfaces:
@@ -38,6 +39,8 @@ platforms:
         ip: 192.168.10.20
   - name: test-cd-ubuntu2004-k8s-runc-cni
     box: generic/ubuntu2004
+    memory: 1024
+    cpus: 2
     groups:
       - ubuntu
     interfaces:
@@ -47,6 +50,8 @@ platforms:
         ip: 192.168.10.30
   - name: test-cd-ubuntu2004-k8s-runc-cni-crictl
     box: generic/ubuntu2004
+    memory: 1024
+    cpus: 2
     groups:
       - ubuntu
     interfaces:
@@ -54,8 +59,10 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.40
-  - name: test-cd-ubuntu1804-k8s-runc-cni-crictl
-    box: generic/ubuntu1804
+  - name: test-cd-ubuntu2204-k8s-runc-cni-crictl
+    box: generic/ubuntu2204
+    memory: 1024
+    cpus: 2
     groups:
       - ubuntu
     interfaces:
@@ -65,6 +72,8 @@ platforms:
         ip: 192.168.10.50
   - name: test-cd-arch-k8s-base
     box: archlinux/archlinux
+    memory: 1024
+    cpus: 2
     groups:
       - archlinux
       - base
@@ -102,7 +111,7 @@ provisioner:
         containerd_cni_binary_directory: "/opt/cni/bin"
         containerd_crictl_config_file: "crictl.yaml"
         containerd_crictl_config_directory: "/etc"
-      test-cd-ubuntu1804-k8s-runc-cni-crictl:
+      test-cd-ubuntu2204-k8s-runc-cni-crictl:
         containerd_flavor: "k8s"
         containerd_runc_binary_directory: "/usr/local/sbin"
         containerd_cni_binary_directory: "/opt/cni/bin"

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -2,7 +2,8 @@
 # Copyright (C) 2021 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: archlinux
+- name: Run tasks for Archlinux
+  hosts: archlinux
   remote_user: vagrant
   become: true
   gather_facts: false
@@ -15,7 +16,9 @@
       failed_when: false
 
     - name: Updating pacman cache
-      raw: pacman -Sy
+      ansible.builtin.raw: |
+        pacman -Sy
+      changed_when: false
 
     - name: Install Python
       ansible.builtin.raw: |
@@ -24,7 +27,8 @@
         executable: /bin/bash
       changed_when: false
 
-- hosts: ubuntu
+- name: Run tasks for Ubuntu
+  hosts: ubuntu
   remote_user: vagrant
   become: true
   gather_facts: true

--- a/molecule/kvm/verify.yml
+++ b/molecule/kvm/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Pull nginx image with ctr
-      ansible.builtin.command: ctr images pull docker.io/library/nginx:1.21 
+      ansible.builtin.command: ctr images pull docker.io/library/nginx:1.21
       register: ctr_pull_output
       changed_when: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,8 @@
   loop: "{{ containerd_binaries }}"
   loop_control:
     loop_var: "binary"
+  notify:
+    - Restart containerd
   tags:
     - containerd-install
 
@@ -114,6 +116,8 @@
     remote_src: true
   tags:
     - runc-install
+  notify:
+    - Restart containerd
   when:
     - containerd_flavor is defined
     - containerd_flavor == "k8s"
@@ -180,6 +184,8 @@
   loop: "{{ containerd_cni_binaries }}"
   loop_control:
     loop_var: "cni_binary"
+  notify:
+    - Restart containerd
   when:
     - containerd_flavor is defined
     - containerd_flavor == "k8s"


### PR DESCRIPTION
- update `containerd` to 'v1.7.3`
- add support for Ubuntu 22.04
- **BREAKING**: remove support for Ubuntu 18.04 (reached end of life)
- **BREAKING**: When `containerd` or `CNI` binaries are upgraded `containerd.service` will be restarted. Up until this version this only happened when `containerd` configuration was updated.