### PR TITLE
0.12.6+1.7.15

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,5 +3,5 @@ extends: default
 
 rules:
   line-length:
-    max: 200
+    max: 300
     level: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 0.12.6+1.7.15
 
-- update `containerd` to `v1.7.15`
+- **UPDATE**
+  - update `containerd` to `v1.7.15`
+
+- **MOLECULE**
+  - use `alvistack` instead of `generic` Vagrant boxes
 
 ## 0.12.5+1.7.13
 
-- update `containerd` to `v1.7.13`
+- **UPDATE**
+  - update `containerd` to `v1.7.13`
 
 ## 0.12.4+1.7.12
 
@@ -37,7 +42,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 ## 0.12.0+1.7.8
 
 - add missing configuration options to make `containerd` work with Kubernetes out of the box: `[plugins."io.containerd.grpc.v1.cri"]` -> `sandbox_image = "registry.k8s.io/pause:3.8"` and `[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc` -> `runtime_type = "io.containerd.runc.v2"`
-- add `"Type": "notify"` to `containerd_config` 
+- add `"Type": "notify"` to `containerd_config`
 
 ## 0.11.0+1.7.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 0.12.6+1.7.15
+
+- update `containerd` to `v1.7.15`
+
 ## 0.12.5+1.7.13
 
 - update `containerd` to `v1.7.13`

--- a/README.md
+++ b/README.md
@@ -17,27 +17,13 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 **Recent changes:**
 
+## 0.12.6+1.7.15
+
+- update `containerd` to `v1.7.15`
+
 ## 0.12.5+1.7.13
 
 - update `containerd` to `v1.7.13`
-
-0.12.4+1.7.12
-
-- add task that creates directory specified in containerd_tmp_directory
-- fix typo in defaults/main.yml
-- Molecule: Change IP addresses
-- Molecule: add two new host variables in `molecule/default/molecule.yml`
-
-0.12.3+1.7.12
-
-NOTE: If you upgrade from a version <= `0.11.0+1.7.8` please read [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/master/CHANGELOG.md) for that version carefully because of breaking changes!
-
-- update `containerd` to `v1.7.12`
-- adjust Github action because of Ansible Galaxy changes
-
-0.12.2+1.7.10
-
-- update `containerd` to `v1.7.10`
 
 Installation
 ------------
@@ -56,7 +42,7 @@ Installation
 roles:
   - name: githubixx.containerd
     src: https://github.com/githubixx/ansible-role-containerd.git
-    version: 0.12.5+1.7.13
+    version: 0.12.6+1.7.15
 ```
 
 Role Variables
@@ -67,7 +53,7 @@ Role Variables
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.7.13"
+containerd_version: "1.7.15"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@ Copyright (C) 2021-2023 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-ansible-role-containerd
-=======================
+# ansible-role-containerd
 
 Ansible role to install [containerd](https://github.com/containerd/containerd). `containerd` is an industry-standard container runtime with an emphasis on simplicity, robustness and portability. It is available as a daemon for Linux and Windows, which can manage the complete container lifecycle of its host system: image transfer and storage, container execution and supervision, low-level storage and network attachments, etc.
 
-Changelog
----------
+## Changelog
 
 **Change history:**
 
@@ -17,16 +15,20 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 **Recent changes:**
 
-## 0.12.6+1.7.15
+### 0.12.6+1.7.15
 
-- update `containerd` to `v1.7.15`
+- **UPDATE**
+  - update `containerd` to `v1.7.15`
 
-## 0.12.5+1.7.13
+- **MOLECULE**
+  - use `alvistack` instead of `generic` Vagrant boxes
 
-- update `containerd` to `v1.7.13`
+### 0.12.5+1.7.13
 
-Installation
-------------
+- **UPDATE**
+  - update `containerd` to `v1.7.13`
+
+## Installation
 
 - Directly download from Github (change into Ansible role directory before cloning):
 `git clone https://github.com/githubixx/ansible-role-containerd.git githubixx.containerd`
@@ -45,8 +47,7 @@ roles:
     version: 0.12.6+1.7.15
 ```
 
-Role Variables
---------------
+## Role Variables
 
 ```yaml
 # Only value "base" is currently supported
@@ -140,8 +141,7 @@ containerd_config: |
       env = ["OCICRYPT_KEYPROVIDER_CONFIG={{ containerd_config_directory }}/ocicrypt/ocicrypt_keyprovider.conf"]
 ```
 
-Dependencies
-------------
+## Dependencies
 
 Optional dependencies (e.g. needed for Kubernetes):
 
@@ -150,8 +150,7 @@ Optional dependencies (e.g. needed for Kubernetes):
 
 You can use every other `runc` and `CNI` role of course.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: your-host
@@ -161,8 +160,7 @@ Example Playbook
 
 More examples are available in the [Molecule tests](https://github.com/githubixx/ansible-role-containerd/tree/master/molecule/kvm).
 
-Testing
--------
+## Testing
 
 This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-containerd/tree/master/molecule/kvm).
 
@@ -186,12 +184,10 @@ To clean up run
 molecule destroy
 ```
 
-License
--------
+## License
 
 GNU GENERAL PUBLIC LICENSE Version 3
 
-Author Information
-------------------
+## Author Information
 
 [http://www.tauceti.blog](http://www.tauceti.blog)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.7.13"
+containerd_version: "1.7.15"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ platforms:
         type: static
         ip: 172.16.10.10
   - name: test-cd-ubuntu2204-base
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:


### PR DESCRIPTION
- **UPDATE**
  - update `containerd` to `v1.7.15`

- **MOLECULE**
  - use `alvistack` instead of `generic` Vagrant boxes