### PR TITLE
0.14.0+2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 molecule/kvm/.vagrant

--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 extends: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 0.14.0+2.0.2
 
+- **POTENTIALLY BREAKING**
+  - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirments of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
+
 - **UPDATE**
   - update `containerd` to `v2.0.2`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 - **POTENTIALLY BREAKING**
   - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirements of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
+  - update list of containerd binaries in `containerd_binaries` variable. `containerd-shim-runc-v1` and `containerd-shim` were removed as no longer provided by upstream.
 
 - **UPDATE**
   - update `containerd` to `v2.0.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
   - update `containerd` to `v2.0.2`
   - `templates/etc/systemd/system/containerd.service.j2`: add `dbus.service` to `After=`
 
+- **MOLECULE**
+  - adjust expected output of `ctr pull` command
+
 ## 0.13.2+1.7.22
 
 - **UPDATE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 ## 0.14.0+2.0.2
 
 - **POTENTIALLY BREAKING**
-  - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirments of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
+  - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirements of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
 
 - **UPDATE**
   - update `containerd` to `v2.0.2`
@@ -80,7 +80,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 0.11.0+1.7.8
 
-**Note** This release contains quite a few breaking changes. This mostly happened because `cri-containerd-*.tar.gz release bundles` are [deprecated](https://github.com/containerd/containerd/blob/main/RELEASES.md#deprecated-features). Also see [cri-containerd.DEPRECATED.txt](https://github.com/containerd/containerd/blob/main/releases/cri-containerd.DEPRECATED.txt). So `containerd` doesn't contain `CNI plugins` and `runc` anymore. You can still use this bundle if you use version `0.10.0+1.7.3` of this Ansible role. But for this version I deciced to remove the support already before `containerd` `v2.0` will be released. That means for `containerd_flavor` only the value `base` can be used and `k8s` has been gone. So that means you have to install [CNI - Container Network Interface](https://github.com/containernetworking/plugins) and [runc](https://github.com/opencontainers/runc) separately. This should happen before you install `containerd`. You can use my Ansible roles
+**Note** This release contains quite a few breaking changes. This mostly happened because `cri-containerd-*.tar.gz release bundles` are [deprecated](https://github.com/containerd/containerd/blob/main/RELEASES.md#deprecated-features). Also see [cri-containerd.DEPRECATED.txt](https://github.com/containerd/containerd/blob/main/releases/cri-containerd.DEPRECATED.txt). So `containerd` doesn't contain `CNI plugins` and `runc` anymore. You can still use this bundle if you use version `0.10.0+1.7.3` of this Ansible role. But for this version I decided to remove the support already before `containerd` `v2.0` will be released. That means for `containerd_flavor` only the value `base` can be used and `k8s` has been gone. So that means you have to install [CNI - Container Network Interface](https://github.com/containernetworking/plugins) and [runc](https://github.com/opencontainers/runc) separately. This should happen before you install `containerd`. You can use my Ansible roles
 
 - For CNI: [ansible-role-cni](https://github.com/githubixx/ansible-role-cni)
 - For runc: [ansible-role-runc](https://github.com/githubixx/ansible-role-runc)
@@ -175,7 +175,7 @@ Other changes:
 
 ## 0.2.0+1.5.8
 
-- add support for Kubernetes by allowing to optionally also install `runc`, `crtcl` and `CNI` plugins. `containerd` builds are available in two flavors: Either just the `containerd` binaries or `containerd` binaries plus everything else needed to use `containerd` together with Kubernetes. Please see [defaults/main.yml](https://github.com/githubixx/ansible-role-containerd/tree/master/defaults/main.yml) for all possible settings. With the Kubernetes support a lot of new variables were introduced but for almost all the default values should be good enough. The default `containerd_flavor: "base"` mimics the behavior of the previous version of this role. So upgrading shouldn't be an issue.
+- add support for Kubernetes by allowing to optionally also install `runc`, `crictl` and `CNI` plugins. `containerd` builds are available in two flavors: Either just the `containerd` binaries or `containerd` binaries plus everything else needed to use `containerd` together with Kubernetes. Please see [defaults/main.yml](https://github.com/githubixx/ansible-role-containerd/tree/master/defaults/main.yml) for all possible settings. With the Kubernetes support a lot of new variables were introduced but for almost all the default values should be good enough. The default `containerd_flavor: "base"` mimics the behavior of the previous version of this role. So upgrading shouldn't be an issue.
 
 ## 0.1.1+1.5.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 - **UPDATE**
   - update `containerd` to `v2.0.2`
+  - `templates/etc/systemd/system/containerd.service.j2`: add `dbus.service` to `After=`
 
 ## 0.13.2+1.7.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 <!--
-Copyright (C) 2021-2024 Robert Wimmer
+Copyright (C) 2021-2025 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
 # Changelog
+
+**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
+
+## 0.14.0+2.0.2
+
+- **UPDATE**
+  - update `containerd` to `v2.0.2`
 
 ## 0.13.2+1.7.22
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 - **POTENTIALLY BREAKING**
   - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirements of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
+  - update list of containerd binaries in `containerd_binaries` variable. `containerd-shim-runc-v1` and `containerd-shim` were removed as no longer provided by upstream.
 
 - **UPDATE**
   - update `containerd` to `v2.0.2`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
   - update `containerd` to `v2.0.2`
   - `templates/etc/systemd/system/containerd.service.j2`: add `dbus.service` to `After=`
 
+- **MOLECULE**
+  - adjust expected output of `ctr pull` command
+
 ## 0.13.2+1.7.22
 
 - **UPDATE**

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ tures so far this version of the Ansible role should cover everything already an
 
 - **UPDATE**
   - update `containerd` to `v2.0.2`
+  - `templates/etc/systemd/system/containerd.service.j2`: add `dbus.service` to `After=`
 
 ## 0.13.2+1.7.22
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2021-2024 Robert Wimmer
+Copyright (C) 2021-2025 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
@@ -14,6 +14,14 @@ Ansible role to install [containerd](https://github.com/containerd/containerd). 
 See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/master/CHANGELOG.md)
 
 **Recent changes:**
+
+## 0.14.0+2.0.2
+
+**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" fea
+tures so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
+
+- **UPDATE**
+  - update `containerd` to `v2.0.2`
 
 ## 0.13.2+1.7.22
 
@@ -49,7 +57,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 roles:
   - name: githubixx.containerd
     src: https://github.com/githubixx/ansible-role-containerd.git
-    version: 0.13.2+1.7.22
+    version: 0.14.0+2.0.2
 ```
 
 ## Role Variables
@@ -59,7 +67,7 @@ roles:
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.7.22"
+containerd_version: "2.0.2"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 ## 0.14.0+2.0.2
 
-**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" fea
-tures so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
+**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
 
 - **POTENTIALLY BREAKING**
-  - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirments of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
+  - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirements of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
 
 - **UPDATE**
   - update `containerd` to `v2.0.2`
@@ -120,8 +119,8 @@ containerd_service_settings:
 
 # Content of configuration file of "containerd". The settings below are the
 # settings that are either different to the default "containerd" settings or
-# stated explicitely to make important settings more visible even if they're
-# default. So these seetings will override the default settings.
+# stated explicitly to make important settings more visible even if they're
+# default. So these settings will override the default settings.
 #
 # The default "containerd" configuration can be generated with this command:
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Only value "base" is currently supported
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "1.7.22"
+containerd_version: "2.0.2"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,8 +55,8 @@ containerd_service_settings:
 
 # Content of configuration file of "containerd". The settings below are the
 # settings that are either different to the default "containerd" settings or
-# stated explicitely to make important settings more visible even if they're
-# default. So these seetings will override the default settings.
+# stated explicitly to make important settings more visible even if they're
+# default. So these settings will override the default settings.
 #
 # The default "containerd" configuration can be generated with this command:
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,41 +54,39 @@ containerd_service_settings:
   "LimitCORE": "infinity"
 
 # Content of configuration file of "containerd". The settings below are the
-# settings that are different to the default "containerd" settings. So these
-# seetings will override the default settings.
+# settings that are either different to the default "containerd" settings or
+# stated explicitely to make important settings more visible even if they're
+# default. So these seetings will override the default settings.
 #
 # The default "containerd" configuration can be generated with this command:
 #
 # containerd config default
 #
+# A full configuration example with all possible options is also available here:
+# https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration
+#
+# Also if you want to adjust settings please consult the CRI Plugin Config Guide:
+# https://github.com/containerd/containerd/blob/main/docs/cri/config.md
+#
 # Difference to default configuration:
 #
-# - The configuration file contains a few role variables that will be replaced when
-#   the configuration template is processed.
 # - In 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' the
 #   setting "SystemdCgroup" is set to "true" instead of "false". This is relevant for
 #   Kubernetes e.g. Also see:
 #   https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd-systemd)
 #
 containerd_config: |
-  version = 2
+  version = 3
   [plugins]
-    [plugins."io.containerd.grpc.v1.cri"]
-      sandbox_image = "registry.k8s.io/pause:3.8"
-      [plugins."io.containerd.grpc.v1.cri".cni]
-        bin_dir = "/opt/cni/bin"
-        conf_dir = "/etc/cni/net.d"
-      [plugins."io.containerd.grpc.v1.cri".containerd]
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-            runtime_type = "io.containerd.runc.v2"
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              BinaryName = "/usr/local/sbin/runc"
+    [plugins.'io.containerd.cri.v1.runtime']
+      [plugins.'io.containerd.cri.v1.runtime'.containerd]
+        default_runtime_name = 'runc'
+        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
+          [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+            runtime_type = 'io.containerd.runc.v2'
+            [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+              BinaryName = '/usr/local/sbin/runc'
               SystemdCgroup = true
-  [stream_processors]
-    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
-      args = ["--decryption-keys-path", "{{ containerd_config_directory }}/ocicrypt/keys"]
-      env = ["OCICRYPT_KEYPROVIDER_CONFIG={{ containerd_config_directory }}/ocicrypt/ocicrypt_keyprovider.conf"]
-    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
-      args = ["--decryption-keys-path", "{{ containerd_config_directory }}/ocicrypt/keys"]
-      env = ["OCICRYPT_KEYPROVIDER_CONFIG={{ containerd_config_directory }}/ocicrypt/ocicrypt_keyprovider.conf"]
+      [plugins.'io.containerd.cri.v1.runtime'.cni]
+        bin_dir = '/opt/cni/bin'
+        conf_dir = '/etc/cni/net.d'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Reload systemd

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 galaxy_info:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Install containerd

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Run tasks for Archlinux

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Verify setup

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,7 +16,7 @@
     - name: Ensure ctr output contains correct string
       ansible.builtin.assert:
         that:
-          - "'done' in ctr_pull_output.stdout"
+          - "'saved' in ctr_pull_output.stdout"
 
     - name: Start nginx with ctr
       ansible.builtin.command:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Include variables depending on flavor

--- a/templates/etc/systemd/system/containerd.service.j2
+++ b/templates/etc/systemd/system/containerd.service.j2
@@ -1,5 +1,5 @@
 #jinja2: trim_blocks:False
-{# Copyright (C) 2021-2024 Robert Wimmer
+{# Copyright (C) 2021-2025 Robert Wimmer
  # SPDX-License-Identifier: GPL-3.0-or-later
  #}
 # {{ ansible_managed }}
@@ -7,7 +7,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target local-fs.target
+After=network.target local-fs.target dbus.service
 
 [Service]
 {%- for setting in containerd_service_settings|sort %}

--- a/vars/flavor_base.yml
+++ b/vars/flavor_base.yml
@@ -5,9 +5,7 @@
 containerd_binaries_src_directory: "/bin"
 
 containerd_binaries:
-  - containerd
-  - containerd-shim
-  - containerd-shim-runc-v1
-  - containerd-shim-runc-v2
   - ctr
+  - containerd
   - containerd-stress
+  - containerd-shim-runc-v2

--- a/vars/flavor_base.yml
+++ b/vars/flavor_base.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 containerd_binaries_src_directory: "/bin"
@@ -10,3 +10,4 @@ containerd_binaries:
   - containerd-shim-runc-v1
   - containerd-shim-runc-v2
   - ctr
+  - containerd-stress


### PR DESCRIPTION

**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!

## 0.14.0+2.0.2

- **POTENTIALLY BREAKING**
  - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirements of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
  - update list of containerd binaries in `containerd_binaries` variable. `containerd-shim-runc-v1` and `containerd-shim` were removed as no longer provided by upstream.

- **UPDATE**
  - update `containerd` to `v2.0.2`
  - `templates/etc/systemd/system/containerd.service.j2`: add `dbus.service` to `After=`

- **MOLECULE**
  - adjust expected output of `ctr pull` command