### PR TITLE
0.15.0+2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - **UPDATE**
   - update `containerd` to `v2.1.3`
 
+- **MOLECULE**
+  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+  - Install `openssl` package for Archlinux
+
 ## 0.14.0+2.0.2
 
 **Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - **MOLECULE**
   - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
   - Install `openssl` package for Archlinux
+  - Removed Ubuntu 20.04 because reached end of life
 
 ## 0.14.0+2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
-**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
+## 0.15.0+2.1.3
+
+- **UPDATE**
+  - update `containerd` to `v2.1.3`
 
 ## 0.14.0+2.0.2
+
+**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
 
 - **POTENTIALLY BREAKING**
   - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirements of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 - **MOLECULE**
   - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
   - Install `openssl` package for Archlinux
+  - Removed Ubuntu 20.04 because reached end of life
 
 ## 0.14.0+2.0.2
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 **Recent changes:**
 
+## 0.15.0+2.1.3
+
+- **UPDATE**
+  - update `containerd` to `v2.1.3`
+
+- **MOLECULE**
+  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+  - Install `openssl` package for Archlinux
+
 ## 0.14.0+2.0.2
 
 **Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
@@ -29,24 +38,6 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 - **MOLECULE**
   - adjust expected output of `ctr pull` command
-
-## 0.13.2+1.7.22
-
-- **UPDATE**
-  - update `containerd` to `v1.7.22`
-
-## 0.13.1+1.7.20
-
-- **UPDATE**
-  - update `containerd` to `v1.7.20`
-
-## 0.13.0+1.7.19
-
-- **FEATURE**
-  - add support for Ubuntu 24.04
-
-- **UPDATE**
-  - update `containerd` to `v1.7.19`
 
 ## Installation
 
@@ -64,7 +55,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 roles:
   - name: githubixx.containerd
     src: https://github.com/githubixx/ansible-role-containerd.git
-    version: 0.14.0+2.0.2
+    version: 0.15.0+2.1.3
 ```
 
 ## Role Variables
@@ -74,7 +65,7 @@ roles:
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.0.2"
+containerd_version: "2.1.3"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.0.2"
+containerd_version: "2.1.3"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,7 +37,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-cd-arch-base
-    box: archlinux/archlinux
+    box: generic/arch
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,17 +14,6 @@ driver:
     type: libvirt
 
 platforms:
-  - name: test-cd-ubuntu2004-base
-    box: generic/ubuntu2004
-    memory: 2048
-    cpus: 2
-    groups:
-      - ubuntu
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.10
   - name: test-cd-ubuntu2204-base
     box: alvistack/ubuntu-22.04
     memory: 2048

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -22,7 +22,7 @@
 
     - name: Install Python
       ansible.builtin.raw: |
-        pacman -S --noconfirm python
+        pacman -S --noconfirm python openssl
       args:
         executable: /bin/bash
       changed_when: false


### PR DESCRIPTION
## 0.15.0+2.1.3

- **UPDATE**
  - update `containerd` to `v2.1.3`

- **MOLECULE**
  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
  - Install `openssl` package for Archlinux
