### PR TITLE
0.16.0+2.1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 molecule/kvm/.vagrant
 .vscode
+.ansible

--- a/.yamllint
+++ b/.yamllint
@@ -8,3 +8,14 @@ rules:
   line-length:
     max: 300
     level: warning
+
+  comments-indentation: disable
+  comments:
+    min-spaces-from-content: 1
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+

--- a/.yamllint
+++ b/.yamllint
@@ -18,4 +18,3 @@ rules:
   octal-values:
     forbid-implicit-octal: true
     forbid-explicit-octal: true
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 0.16.0+2.1.4
+
+- **Breaking**
+  - `meta/main.yml`: Change `min_ansible_version` to 2.15. Ansible 2.9 is end-of-life (EOL).
+
+- **UPDATE**
+  - update `containerd` to `v2.1.4`
+
 ## 0.15.0+2.1.3
 
 - **UPDATE**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
   - update `containerd` to `v2.1.4`
   - update `.gitignore`
   - update `.yamllint`
+  - fix `ansible-lint` issues
 
 ## 0.15.0+2.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 - **UPDATE**
   - update `containerd` to `v2.1.4`
+  - update `.gitignore`
 
 ## 0.15.0+2.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - **UPDATE**
   - update `containerd` to `v2.1.4`
   - update `.gitignore`
+  - update `.yamllint`
 
 ## 0.15.0+2.1.3
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 - **UPDATE**
   - update `containerd` to `v2.1.4`
+  - update `.gitignore`
 
 ## 0.15.0+2.1.3
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 **Recent changes:**
 
+## 0.16.0+2.1.4
+
+- **Breaking**
+  - `meta/main.yml`: Change `min_ansible_version` to 2.15. Ansible 2.9 is end-of-life (EOL).
+
+- **UPDATE**
+  - update `containerd` to `v2.1.4`
+
 ## 0.15.0+2.1.3
 
 - **UPDATE**
@@ -56,7 +64,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 roles:
   - name: githubixx.containerd
     src: https://github.com/githubixx/ansible-role-containerd.git
-    version: 0.15.0+2.1.3
+    version: 0.16.0+2.1.4
 ```
 
 ## Role Variables
@@ -66,7 +74,7 @@ roles:
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.1.3"
+containerd_version: "2.1.4"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
   - update `containerd` to `v2.1.4`
   - update `.gitignore`
   - update `.yamllint`
+  - fix `ansible-lint` issues
 
 ## 0.15.0+2.1.3
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 - **UPDATE**
   - update `containerd` to `v2.1.4`
   - update `.gitignore`
+  - update `.yamllint`
 
 ## 0.15.0+2.1.3
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.1.3"
+containerd_version: "2.1.4"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,14 +6,13 @@ galaxy_info:
   author: Robert Wimmer
   description: Ansible role to install containerd
   license: GPLv3
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.15"
   role_name: containerd
   namespace: githubixx
   platforms:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "focal"
         - "jammy"
         - "noble"
   galaxy_tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: "{{ containerd_tmp_directory }}"
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: root
     group: root
   tags:
@@ -24,7 +24,7 @@
     url: "{{ containerd_url }}"
     dest: "{{ containerd_tmp_directory }}/containerd.tar.gz"
     checksum: "sha256:{{ containerd_url }}.sha256sum"
-    mode: 0600
+    mode: "0600"
   tags:
     - containerd-install
     - containerd-download
@@ -58,7 +58,7 @@
   ansible.builtin.file:
     path: "{{ containerd_config_directory }}"
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
   tags:
@@ -71,7 +71,7 @@
     dest: "{{ containerd_config_directory }}/config.toml"
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify:
     - Restart containerd
   tags:
@@ -109,7 +109,7 @@
     dest: /etc/systemd/system/containerd.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify:
     - Reload systemd
     - Restart containerd


### PR DESCRIPTION
- **Breaking**
  - `meta/main.yml`: Change `min_ansible_version` to 2.15. Ansible 2.9 is end-of-life (EOL).

- **UPDATE**
  - update `containerd` to `v2.1.4`
  - update `.gitignore`
  - update `.yamllint`
  - fix `ansible-lint` issues
