### PR TITLE
0.17.0+2.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 molecule/kvm/.vagrant

--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 extends: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+- **UPDATE**
+  - update `containerd` to `v2.2.1`
+
 ## 0.16.0+2.1.4
 
 - **Breaking**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2021-2025 Robert Wimmer
+Copyright (C) 2021-2026 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - **UPDATE**
   - update `containerd` to `v2.2.1`
 
+- **FEATURE**
+  - support `conf.d` include in the [default config](https://github.com/containerd/containerd/pull/12323)
+
+- **MOLECULE**
+  - add test for `conf.d` include feature
+
 ## 0.16.0+2.1.4
 
 - **Breaking**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+- **BREAKING**
+  - CNI `bin_dir` in CRI runtime config is deprecated (`plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir`) and will be removed in containerd `v2.3`. It was replaced with `bin_dirs` in the same section which supports a list of directories. So, `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'` was changed to `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']` in `containerd_config` variable.
+
 - **UPDATE**
   - update `containerd` to `v2.2.1`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2021-2025 Robert Wimmer
+Copyright (C) 2021-2026 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 **Recent changes:**
 
+## 0.17.0+2.2.1
+
+- **UPDATE**
+  - update `containerd` to `v2.2.1`
+
 ## 0.16.0+2.1.4
 
 - **Breaking**
@@ -67,7 +72,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 roles:
   - name: githubixx.containerd
     src: https://github.com/githubixx/ansible-role-containerd.git
-    version: 0.16.0+2.1.4
+    version: 0.17.0+2.2.1
 ```
 
 ## Role Variables
@@ -77,7 +82,7 @@ roles:
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.1.4"
+containerd_version: "2.2.1"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 ## 0.17.0+2.2.1
 
+- **BREAKING**
+  - CNI `bin_dir` in CRI runtime config is deprecated (`plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir`) and will be removed in containerd `v2.3`. It was replaced with `bin_dirs` in the same section which supports a list of directories. So, `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'` was changed to `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']` in `containerd_config` variable.
+
 - **UPDATE**
   - update `containerd` to `v2.2.1`
 
@@ -170,7 +173,7 @@ containerd_config: |
               BinaryName = '/usr/local/sbin/runc'
               SystemdCgroup = true
       [plugins.'io.containerd.cri.v1.runtime'.cni]
-        bin_dir = '/opt/cni/bin'
+        bin_dirs = ['/opt/cni/bin']
         conf_dir = '/etc/cni/net.d'
 
 # Optional: containerd config drop-ins via `imports` (containerd >= v2.2.0)
@@ -191,7 +194,7 @@ containerd_config: |
 #         disabled_plugins = []
 #
 #       20-cni.toml: |
-#         plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'
+#         plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']
 #         plugins.'io.containerd.cri.v1.runtime'.cni.conf_dir = '/etc/cni/net.d'
 #
 # Example 2: Import additional directories but manage files elsewhere

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 - **UPDATE**
   - update `containerd` to `v2.2.1`
 
+- **FEATURE**
+  - support `conf.d` include in the [default config](https://github.com/containerd/containerd/pull/12323)
+
+- **MOLECULE**
+  - add test for `conf.d` include feature
+
 ## 0.16.0+2.1.4
 
 - **Breaking**
@@ -166,6 +172,49 @@ containerd_config: |
       [plugins.'io.containerd.cri.v1.runtime'.cni]
         bin_dir = '/opt/cni/bin'
         conf_dir = '/etc/cni/net.d'
+
+# Optional: containerd config drop-ins via `imports` (containerd >= v2.2.0)
+#
+# If you set `containerd_config_imports`, the role will:
+# - add `imports = [ ... ]` to the generated `config.toml` (unless your
+#   `containerd_config` already contains an `imports = ...` line)
+# - optionally create the referenced directories and manage `.toml` drop-in files
+#   defined under `configs`.
+#
+# Example 1: Enable imports and manage a few drop-in files in `/etc/containerd/conf.d`
+#
+# containerd_config_imports:
+#   - glob: "/etc/containerd/conf.d/*.toml"
+#     configs:
+#       10-nvidia.toml: |
+#         # Example override (use dotted keys to avoid table re-definition issues)
+#         disabled_plugins = []
+#
+#       20-cni.toml: |
+#         plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'
+#         plugins.'io.containerd.cri.v1.runtime'.cni.conf_dir = '/etc/cni/net.d'
+#
+# Example 2: Import additional directories but manage files elsewhere
+#
+# containerd_config_imports:
+#   - glob: "/etc/containerd/conf.d/*.toml"
+#   - glob: "/etc/containerd/conf2.d/*.toml"
+#
+# Example 3: Override an existing default setting via a drop-in
+# (here: switch SystemdCgroup to false)
+#
+# containerd_config_imports:
+#   - glob: "/etc/containerd/conf.d/*.toml"
+#     configs:
+#       10-runc-options.toml: |
+#         plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options.SystemdCgroup = false
+#
+# Variable definition (default: disabled)
+containerd_config_imports: []
+
+# Validate the combined config (main config + imported drop-ins).
+# Uses: `containerd --config <path> config dump`. If invalid, the play fails.
+containerd_validate_config: false
 ```
 
 ## Dependencies
@@ -189,7 +238,7 @@ More examples are available in the [Molecule tests](https://github.com/githubixx
 
 ## Testing
 
-This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-containerd/tree/master/molecule/kvm).
+This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is in [molecule/kvm](https://github.com/githubixx/ansible-role-containerd/tree/master/molecule/kvm).
 
 Afterwards molecule can be executed:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,7 +88,7 @@ containerd_config: |
               BinaryName = '/usr/local/sbin/runc'
               SystemdCgroup = true
       [plugins.'io.containerd.cri.v1.runtime'.cni]
-        bin_dir = '/opt/cni/bin'
+        bin_dirs = ['/opt/cni/bin']
         conf_dir = '/etc/cni/net.d'
 
 # Optional: containerd config drop-ins via `imports` (containerd >= v2.2.0)
@@ -109,7 +109,7 @@ containerd_config: |
 #         disabled_plugins = []
 #
 #       20-cni.toml: |
-#         plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'
+#         plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']
 #         plugins.'io.containerd.cri.v1.runtime'.cni.conf_dir = '/etc/cni/net.d'
 #
 # Example 2: Import additional directories but manage files elsewhere

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Only value "base" is currently supported

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.1.4"
+containerd_version: "2.2.1"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,3 +90,46 @@ containerd_config: |
       [plugins.'io.containerd.cri.v1.runtime'.cni]
         bin_dir = '/opt/cni/bin'
         conf_dir = '/etc/cni/net.d'
+
+# Optional: containerd config drop-ins via `imports` (containerd >= v2.2.0)
+#
+# If you set `containerd_config_imports`, the role will:
+# - add `imports = [ ... ]` to the generated `config.toml` (unless your
+#   `containerd_config` already contains an `imports = ...` line)
+# - optionally create the referenced directories and manage `.toml` drop-in files
+#   defined under `configs`.
+#
+# Example 1: Enable imports and manage a few drop-in files in `/etc/containerd/conf.d`
+#
+# containerd_config_imports:
+#   - glob: "/etc/containerd/conf.d/*.toml"
+#     configs:
+#       10-nvidia.toml: |
+#         # Example override (use dotted keys to avoid table re-definition issues)
+#         disabled_plugins = []
+#
+#       20-cni.toml: |
+#         plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'
+#         plugins.'io.containerd.cri.v1.runtime'.cni.conf_dir = '/etc/cni/net.d'
+#
+# Example 2: Import additional directories but manage files elsewhere
+#
+# containerd_config_imports:
+#   - glob: "/etc/containerd/conf.d/*.toml"
+#   - glob: "/etc/containerd/conf2.d/*.toml"
+#
+# Example 3: Override an existing default setting via a drop-in
+# (here: switch SystemdCgroup to false)
+#
+# containerd_config_imports:
+#   - glob: "/etc/containerd/conf.d/*.toml"
+#     configs:
+#       10-runc-options.toml: |
+#         plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options.SystemdCgroup = false
+#
+# Variable definition (default: disabled)
+containerd_config_imports: []
+
+# Validate the combined config (main config + imported drop-ins).
+# Uses: `containerd --config <path> config dump`. If invalid, the play fails.
+containerd_validate_config: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Reload systemd

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 galaxy_info:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Install containerd

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -36,6 +36,18 @@ platforms:
         network_name: private_network
         type: static
         ip: 172.16.10.30
+  - name: test-cd-ubuntu2404-conf-d
+    box: alvistack/ubuntu-24.04
+    memory: 2048
+    cpus: 2
+    groups:
+      - ubuntu
+      - confd
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.40
   - name: test-cd-arch-base
     box: generic/arch
     memory: 2048
@@ -46,7 +58,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 172.16.10.40
+        ip: 172.16.10.50
 
 provisioner:
   name: ansible
@@ -60,6 +72,14 @@ provisioner:
       all:
         containerd_tmp_directory: "/opt/tmp/containerd"
         containerd_binary_directory: "/usr/local/sbin"
+      test-cd-ubuntu2404-conf-d:
+        containerd_validate_config: true
+        containerd_config_imports:
+          - glob: "/etc/containerd/conf.d/*.toml"
+            configs:
+              10-molecule.toml: |
+                # Simple, non-critical override to prove imports work
+                plugins."io.containerd.cri.v1.runtime".max_container_log_line_size = 32768
 
 scenario:
   name: default

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Run tasks for Archlinux

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Verify setup

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,7 +6,68 @@
   hosts: all
   vars:
     containerd__nginx_version: "1.24"
+    # Molecule verifier doesn't automatically load role defaults, so provide
+    # safe fallbacks and discover the actual containerd binary path.
+    containerd__config_directory: "{{ containerd_config_directory | default('/etc/containerd') }}"
+    containerd__candidate_binaries:
+      - "{{ (containerd_binary_directory | default('/usr/local/sbin')) }}/containerd"
+      - "{{ (containerd_binary_directory | default('/usr/local/bin')) }}/containerd"
+      - "/usr/local/sbin/containerd"
+      - "/usr/local/bin/containerd"
+      - "/usr/bin/containerd"
   tasks:
+    - name: Locate containerd binary
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop: "{{ containerd__candidate_binaries }}"
+      register: containerd__binary_stats
+      changed_when: false
+
+    - name: Set containerd binary path
+      ansible.builtin.set_fact:
+        containerd__binary_path: "{{ (containerd__binary_stats.results | selectattr('stat.exists', '==', True) | map(attribute='stat.path') | first) }}"
+
+    - name: Assert containerd binary found
+      ansible.builtin.assert:
+        that:
+          - containerd__binary_path is defined
+          - containerd__binary_path | length > 0
+        fail_msg: "containerd binary not found in candidate paths: {{ containerd__candidate_binaries }}"
+
+    - name: Verify conf.d imports behavior
+      when: inventory_hostname == 'test-cd-ubuntu2404-conf-d'
+      block:
+        - name: Read containerd main config
+          ansible.builtin.slurp:
+            src: "{{ containerd__config_directory }}/config.toml"
+          register: containerd_config_toml
+
+        - name: Ensure imports are configured in main config
+          ansible.builtin.assert:
+            that:
+              - "(containerd_config_toml.content | b64decode) is regex('(?m)^\\s*imports\\s*=\\s*\\[.*conf\\.d/\\*\\.toml.*\\]')"
+
+        - name: Ensure conf.d drop-in file exists
+          ansible.builtin.stat:
+            path: "{{ containerd__config_directory }}/conf.d/10-molecule.toml"
+          register: containerd_dropin_stat
+
+        - name: Assert conf.d drop-in file exists
+          ansible.builtin.assert:
+            that:
+              - containerd_dropin_stat.stat.exists
+
+        - name: Dump containerd config (main + imports)
+          ansible.builtin.command:
+            cmd: "{{ containerd__binary_path }} --config {{ containerd__config_directory }}/config.toml config dump"
+          register: containerd_config_dump
+          changed_when: false
+
+        - name: Ensure conf.d drop-in override is present
+          ansible.builtin.assert:
+            that:
+              - "containerd_config_dump.stdout is regex('(?m)^\\s*max_container_log_line_size\\s*=\\s*32768\\s*$')"
+
     - name: Pull nginx image with ctr
       ansible.builtin.command:
         cmd: "ctr images pull docker.io/library/nginx:{{ containerd__nginx_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,15 +65,82 @@
     - containerd-install
     - containerd-config
 
+- name: Compute containerd import globs
+  ansible.builtin.set_fact:
+    containerd__config_import_globs: >-
+      {{
+        (containerd_config_imports | default([]) | map(attribute='glob') | list)
+        if (containerd_config_imports is sequence and (containerd_config_imports | length > 0) and (containerd_config_imports[0] is mapping))
+        else (containerd_config_imports | default([]) | list)
+      }}
+  tags:
+    - containerd-install
+    - containerd-config
+
+- name: Define newline helper for config rendering
+  ansible.builtin.set_fact:
+    # YAML double-quoted "\n" becomes a real newline character.
+    containerd__nl: "\n"
+  tags:
+    - containerd-install
+    - containerd-config
+
+- name: Render containerd config (optionally inject imports)
+  ansible.builtin.set_fact:
+    containerd__config_rendered: >-
+      {{
+        containerd_config
+        if (
+          (containerd__config_import_globs | length == 0)
+          or (containerd_config is regex('(?m)^\s*imports\s*='))
+        )
+        else (
+          (containerd_config.splitlines()[:1] | join(containerd__nl))
+          ~ containerd__nl
+          ~ 'imports = [' ~ (containerd__config_import_globs | map('to_json') | join(', ')) ~ ']'
+          ~ containerd__nl
+          ~ (containerd_config.splitlines()[1:] | join(containerd__nl))
+          ~ containerd__nl
+        )
+      }}
+  tags:
+    - containerd-install
+    - containerd-config
+
 - name: Create containerd configuration file
   ansible.builtin.copy:
-    content: "{{ containerd_config }}"
+    content: "{{ containerd__config_rendered }}"
     dest: "{{ containerd_config_directory }}/config.toml"
     owner: root
     group: root
     mode: "0644"
   notify:
     - Restart containerd
+  tags:
+    - containerd-install
+    - containerd-config
+
+
+- name: Manage containerd drop-in config directories and files
+  ansible.builtin.include_tasks: manage_import.yml
+  when:
+    - containerd_config_imports is sequence
+    - containerd_config_imports | length > 0
+    - containerd_config_imports[0] is mapping
+  loop: "{{ containerd_config_imports | default([]) }}"
+  loop_control:
+    loop_var: containerd__import
+    label: "{{ containerd__import.glob }}"
+  tags:
+    - containerd-install
+    - containerd-config
+
+- name: Validate containerd configuration (main + imports)
+  when: containerd_validate_config | bool
+  ansible.builtin.command:
+    cmd: "{{ containerd_binary_directory }}/containerd --config {{ containerd_config_directory }}/config.toml config dump"
+  register: containerd__config_dump
+  changed_when: false
   tags:
     - containerd-install
     - containerd-config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Include variables depending on flavor

--- a/tasks/manage_import.yml
+++ b/tasks/manage_import.yml
@@ -1,0 +1,26 @@
+---
+# Copyright (C) 2021-2026 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create containerd drop-in config directory
+  ansible.builtin.file:
+    path: "{{ containerd__import.glob | regex_replace('/[^/]+$', '') }}"
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Write containerd drop-in config files
+  when: (containerd__import.configs | default({}) | length) > 0
+  ansible.builtin.copy:
+    content: "{{ containerd__cfg.value }}"
+    dest: "{{ containerd__import.glob | regex_replace('/[^/]+$', '') }}/{{ containerd__cfg.key }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ (containerd__import.configs | default({})) | dict2items }}"
+  loop_control:
+    loop_var: containerd__cfg
+    label: "{{ containerd__import.glob | regex_replace('/[^/]+$', '') }}/{{ containerd__cfg.key }}"
+  notify:
+    - Restart containerd

--- a/templates/etc/systemd/system/containerd.service.j2
+++ b/templates/etc/systemd/system/containerd.service.j2
@@ -1,5 +1,5 @@
 #jinja2: trim_blocks:False
-{# Copyright (C) 2021-2025 Robert Wimmer
+{# Copyright (C) 2021-2026 Robert Wimmer
  # SPDX-License-Identifier: GPL-3.0-or-later
  #}
 # {{ ansible_managed }}

--- a/vars/flavor_base.yml
+++ b/vars/flavor_base.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 containerd_binaries_src_directory: "/bin"


### PR DESCRIPTION
- **BREAKING**
  - CNI `bin_dir` in CRI runtime config is deprecated (`plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir`) and will be removed in containerd `v2.3`. It was replaced with `bin_dirs` in the same section which supports a list of directories. So, `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'` was changed to `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']` in `containerd_config` variable.

- **UPDATE**
  - update `containerd` to `v2.2.1`

- **FEATURE**
  - support `conf.d` include in the [default config](https://github.com/containerd/containerd/pull/12323)

- **MOLECULE**
  - add test for `conf.d` include feature
