### PR TITLE
0.18.0+2.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+Guidance for AI/code agents and contributors working on this role.
+
+## Scope
+
+- Repository: `githubixx.containerd`
+- Primary concerns: containerd provisioning reliability, Molecule test quality, lint-clean Ansible/Jinja.
+
+## Working Style
+
+- Keep changes **small and commit-sized** (one test/theme per change where possible).
+- Prefer root-cause fixes over suppressions.
+- Do not add unrelated refactors while addressing lint/test failures.
+
+## Molecule Expectations
+
+- Scenario sequence must include idempotence and verify:
+  - `prepare`
+  - `converge`
+  - `idempotence`
+  - `verify`
+- Verify coverage is expected for:
+  - containerd service health
+  - listener ports
+  - API health endpoints
+
+## Ansible Lint Rules to Respect
+
+- Avoid `systemctl` via `command`/`shell` for state checks.
+  - Use `ansible.builtin.service_facts` + `ansible.builtin.assert`.
+- If `shell` uses pipes, enable pipefail:
+  - `set -o pipefail && ...`
+  - `args.executable: /bin/bash`
+- Avoid `curl` in tasks where `uri` is appropriate.
+  - Use `ansible.builtin.uri` for HTTP health checks.
+
+## Facts Access (Important)
+
+- Injected top-level facts are deprecated; do not rely on `ansible_<iface>` or `ansible_default_ipv4` as top-level vars.
+- Use `ansible_facts` dictionary access with fallbacks, e.g.:
+  - `ansible_facts.get(interface, {}).get('ipv4', {}).get('address', ansible_facts.get('default_ipv4', {}).get('address'))`
+- When accessing other hosts, use:
+  - `hostvars[host].ansible_facts...`
+
+## Jinja Templating Pitfalls
+
+- Be careful with folded scalars (`>-`) and multiline Jinja: they can inject whitespace/newlines into CLI args.
+- For single-line output values used in URLs/flags, use whitespace control:
+  - `{%- ... -%}` and `{{- ... -}}`
+- Keep long expressions readable, but ensure rendered output stays whitespace-safe.
+
+## Verify Playbook Conventions
+
+- `verify.yml` should validate system state and API behavior without mutating cluster state.
+- For robustness in Molecule, prefer local fallback vars when role defaults may not be in scope.
+- Keep task names explicit and failure messages signal-rich via assertions.
+
+## Documentation Sync
+
+- If runtime templates/defaults change (especially fact access style), update `README.md` examples in the same change.
+- Keep changelog entries concise and grouped by update type.
+
+## Quick Pre-merge Checklist
+
+- `ansible-lint` clean for changed files.
+- No deprecated injected-facts usage introduced.
+- No shell pipe without pipefail.
+- Molecule scenario still includes idempotence and verify.
+- New/changed verify tasks are deterministic across supported test VMs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 0.18.0+2.3.0
+
+- **UPDATE**
+  - update `containerd` to `v2.3.0`
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
+
+## 0.17.0+2.2.1
+
 - **BREAKING**
   - CNI `bin_dir` in CRI runtime config is deprecated (`plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir`) and will be removed in containerd `v2.3`. It was replaced with `bin_dirs` in the same section which supports a list of directories. So, `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'` was changed to `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']` in `containerd_config` variable.
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,18 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 
 **Recent changes:**
 
+## 0.18.0+2.3.0
+
+- **UPDATE**
+  - update `containerd` to `v2.3.0`
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
+
 ## 0.17.0+2.2.1
 
 - **BREAKING**
   - CNI `bin_dir` in CRI runtime config is deprecated (`plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir`) and will be removed in containerd `v2.3`. It was replaced with `bin_dirs` in the same section which supports a list of directories. So, `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'` was changed to `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']` in `containerd_config` variable.
-
-- **UPDATE**
-  - update `containerd` to `v2.2.1`
 
 - **FEATURE**
   - support `conf.d` include in the [default config](https://github.com/containerd/containerd/pull/12323)
@@ -81,7 +86,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 roles:
   - name: githubixx.containerd
     src: https://github.com/githubixx/ansible-role-containerd.git
-    version: 0.17.0+2.2.1
+    version: 0.18.0+2.3.0
 ```
 
 ## Role Variables
@@ -91,7 +96,7 @@ roles:
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.2.1"
+containerd_version: "2.3.0"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
 - **BREAKING**
   - CNI `bin_dir` in CRI runtime config is deprecated (`plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir`) and will be removed in containerd `v2.3`. It was replaced with `bin_dirs` in the same section which supports a list of directories. So, `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dir = '/opt/cni/bin'` was changed to `plugins.'io.containerd.cri.v1.runtime'.cni.bin_dirs = ['/opt/cni/bin']` in `containerd_config` variable.
 
+- **UPDATE**
+  - update `containerd` to `v2.2.1`
+
 - **FEATURE**
   - support `conf.d` include in the [default config](https://github.com/containerd/containerd/pull/12323)
 
@@ -44,31 +47,6 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-containerd/blob/m
   - update `.gitignore`
   - update `.yamllint`
   - fix `ansible-lint` issues
-
-## 0.15.0+2.1.3
-
-- **UPDATE**
-  - update `containerd` to `v2.1.3`
-
-- **MOLECULE**
-  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
-  - Install `openssl` package for Archlinux
-  - Removed Ubuntu 20.04 because reached end of life
-
-## 0.14.0+2.0.2
-
-**Note**: This a major release update to `containerd` version `2.0.2`! Please read the [changelog of containerd v2.0.2](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) accordingly! In general if you haven't used any "exotic" features so far this version of the Ansible role should cover everything already and upgrading should be smooth. Nevertheless you should test the changes before!
-
-- **POTENTIALLY BREAKING**
-  - `containerd_config` variable value was adjusted to to meet `containerd` configuration requirements of version `3`. Please see [Full configuration](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#full-configuration) for all possible values. If you haven't adjusted this variable then there should be no need to change anything and upgrading should be smooth.
-  - update list of containerd binaries in `containerd_binaries` variable. `containerd-shim-runc-v1` and `containerd-shim` were removed as no longer provided by upstream.
-
-- **UPDATE**
-  - update `containerd` to `v2.0.2`
-  - `templates/etc/systemd/system/containerd.service.j2`: add `dbus.service` to `After=`
-
-- **MOLECULE**
-  - adjust expected output of `ctr pull` command
 
 ## Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 containerd_flavor: "base"
 
 # containerd version to install
-containerd_version: "2.2.1"
+containerd_version: "2.3.0"
 
 # Directory where to store "containerd" binaries
 containerd_binary_directory: "/usr/local/bin"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ driver:
 
 platforms:
   - name: test-cd-ubuntu2204-base
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -26,7 +26,7 @@ platforms:
         type: static
         ip: 172.16.10.20
   - name: test-cd-ubuntu2404-base
-    box: alvistack/ubuntu-24.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -37,7 +37,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-cd-ubuntu2404-conf-d
-    box: alvistack/ubuntu-24.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -49,7 +49,7 @@ platforms:
         type: static
         ip: 172.16.10.40
   - name: test-cd-arch-base
-    box: generic/arch
+    box: githubixx/archlinux
     memory: 2048
     cpus: 2
     groups:


### PR DESCRIPTION
- **UPDATE**
  - update `containerd` to `v2.3.0`

- **MOLECULE**
  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)